### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM node:16-alpine AS build
 
 WORKDIR /usr/src/app
-COPY public ./public
-# RUN mkdir /usr/src/app/build
-# COPY ./env.sh /usr/src/app/build/env.sh
-# COPY ./.env.base /usr/src/app/build/env.base
-COPY tsconfig.json package.json yarn.lock craco.config.js tailwind.config.js ./
-RUN yarn install
-COPY src ./src
+
+# separate for docker layer caching
+COPY package.json yarn.lock ./
+RUN yarn install --immutable --immutable-cache --check-cache
+
+COPY . .
 RUN yarn build
 
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:fix": "eslint --fix --ext .js,.jsx,.ts,.tsx src",
     "nibble": "eslint-nibble --ext .js,.jsx,.ts,.tsx src",
     "svg-sprite:build": "node scripts/buildSvgSprite.js",
-    "svg-sprite:type": "node scripts/generateIconsType.js"
+    "svg-sprite:type": "node scripts/generateIconsType.js",
+    "docker:build": "DOCKER_BUILDKIT=1 docker build -t ui-client:latest ."
   },
   "dependencies": {
     "@headlessui/react": "^1.2.0",


### PR DESCRIPTION
Certain files weren't copied.

Now just copy everything.
Reduce the files used for the yarn install layer caching.
Safer yarn install, throw errors if lockfile isn't correct.
Add package run script to test docker build process.