### PR TITLE
Remove env-config from index.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# Temporary env files
-/public/env-config.js
-env-config.js
-
 /src/style/tailwind.output.css

--- a/public/disconnect.html
+++ b/public/disconnect.html
@@ -13,9 +13,6 @@
     <meta name="description" content="Odyssey Momentum"/>
     <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png"/>
 
-    <!-- Preload config variables into window._env_ -->
-<!--    <script src="%PUBLIC_URL%/env-config.js"></script>-->
-    
 <!--    <link rel="stylesheet" href="unity/TemplateData/style.css">-->
 
     <!--

--- a/public/index.html
+++ b/public/index.html
@@ -13,9 +13,6 @@
     <meta name="description" content="Odyssey Momentum"/>
     <link rel="apple-touch-icon" href="/favicon/apple-touch-icon.png"/>
 
-    <!-- Preload config variables into window._env_ -->
-    <script src="%PUBLIC_URL%/env-config.js"></script>
-
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
Avoids the error when browser tries to read 404 response as JS.

Cleanup some other mentions.

Some cleanup after
https://github.com/momentum-xyz/bugs-and-features/issues/1776