### PR TITLE
feature(space): close buttons for Miro & Google Drive

### DIFF
--- a/src/scenes/collaboration/pages/GoogleDrivePage/GoogleDrivePage.tsx
+++ b/src/scenes/collaboration/pages/GoogleDrivePage/GoogleDrivePage.tsx
@@ -82,7 +82,7 @@ const GoogleDrivePage: FC = () => {
         {space.isAdmin && !!googleDocument?.data?.url && (
           <>
             <Button label={t('actions.changeDocument')} variant="primary" onClick={pickDocument} />
-            <Button label={t('actions.cancel')} variant="danger" onClick={closeDocument} />
+            <Button label={t('actions.close')} variant="danger" onClick={closeDocument} />
           </>
         )}
       </SpaceTopBar>

--- a/src/scenes/collaboration/pages/MiroBoardPage/MiroBoardPage.tsx
+++ b/src/scenes/collaboration/pages/MiroBoardPage/MiroBoardPage.tsx
@@ -77,7 +77,7 @@ const MiroBoardPage: FC = () => {
         {space.isAdmin && !!miroBoard?.data?.accessLink && (
           <>
             <Button label={t('actions.changeBoard')} variant="primary" onClick={pickBoard} />
-            <Button label={t('actions.cancel')} variant="danger" onClick={closeBoard} />
+            <Button label={t('actions.close')} variant="danger" onClick={closeBoard} />
           </>
         )}
       </SpaceTopBar>


### PR DESCRIPTION
#DEV-65
Rename the "Cancel" button for Miro and Google Drive to "Close".
[https://momentum.nifty.pm/l/dmUVA8KgIWz](https://momentum.nifty.pm/l/dmUVA8KgIWz)