### PR TITLE
fix(collaboration): infinite redirection/render loop with Stage Mode

### DIFF
--- a/src/scenes/collaboration/Collaboration.tsx
+++ b/src/scenes/collaboration/Collaboration.tsx
@@ -196,11 +196,13 @@ const Collaboration: FC = () => {
     ];
   });
 
+  const routes = React.useMemo(() => COLLABORATION_ROUTES(spaceId, plugins), [plugins, spaceId]);
+
   return (
     <styled.Container>
       <Navigation tabs={tabs} />
 
-      {createSwitchByConfig(COLLABORATION_ROUTES(spaceId, plugins))}
+      {createSwitchByConfig(routes)}
 
       {newDeviceDialog.isOpen && (
         <NewDeviceDialog


### PR DESCRIPTION
It's because COLLABORATION_ROUTES is now a function, generating new instance of routes and their "main" properties used as components for render. It all is probably a temp solution and later routes and this fix can go back to being static array.

#BAS-28
https://momentum.nifty.pm/l/nxu5s!IKnZ6I