### PR TITLE
Plugin SDK Host Emulator

### DIFF
--- a/packages/plugin_miro/src/bootstrap.tsx
+++ b/packages/plugin_miro/src/bootstrap.tsx
@@ -3,10 +3,15 @@ import ReactDOM from 'react-dom';
 import 'static/styles/index.css';
 import styled, {ThemeProvider} from 'styled-components';
 import {DefaultThemeConfig} from '@momentum-xyz/ui-kit';
+import {HostEmulator} from '@momentum-xyz/sdk';
 import {MomentumRequiredPage} from 'pages/MomentumRequiredPage';
 
 import '@momentum-xyz/ui-kit/dist/themes/themes';
 import 'shared/services/i18n';
+
+import plugin from './Plugin';
+
+const isDevEnv = process.env.NODE_ENV === 'development';
 
 const root = document.getElementById('root') as HTMLElement;
 
@@ -19,7 +24,7 @@ ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={DefaultThemeConfig}>
       <Container>
-        <MomentumRequiredPage />
+        {isDevEnv ? <HostEmulator plugin={plugin} /> : <MomentumRequiredPage />}
       </Container>
     </ThemeProvider>
   </React.StrictMode>,

--- a/packages/sdk/src/emulator/HostEmulator.styled.ts
+++ b/packages/sdk/src/emulator/HostEmulator.styled.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+export const SpaceLayout = styled.div`
+  display: flex;
+  gap: 10px;
+  height: 100%;
+  width: 100%;
+`;
+
+export const SpaceNav = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 500px;
+  width: 120px;
+  border: 1px solid grey;
+  border-radius: 4px;
+  padding: 10px;
+  margin: 10px;
+  gap: 10px;
+`;
+
+export const SpaceTab = styled.button`
+  border: 1px solid grey;
+  padding: 10px;
+  cursor: pointer;
+  &:hover {
+    background-color: grey;
+  }
+`;
+
+export const SpaceContent = styled.div`
+  flex: 1 0 auto;
+  border: 1px solid grey;
+  margin: 10px;
+`;
+
+export const SpaceTopBar = styled.div`
+  display: flex;
+  height: 50px;
+  border: 1px solid grey;
+  border-radius: 4px;
+  margin: 10px;
+  padding: 10px;
+  gap: 10px;
+`;

--- a/packages/sdk/src/emulator/HostEmulator.tsx
+++ b/packages/sdk/src/emulator/HostEmulator.tsx
@@ -1,0 +1,73 @@
+import {FC, useCallback, useState} from 'react';
+import {CorePluginPropsInterface, PluginInterface} from 'interfaces';
+import {useTheme} from 'styled-components';
+import {ErrorBoundary, ThemeInterface} from '@momentum-xyz/ui-kit';
+import axios, {AxiosInstance} from 'axios';
+
+import * as styled from './HostEmulator.styled';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const defaultHeaders: Record<string, string> = {
+  'Content-Type': 'application/json'
+};
+const request: AxiosInstance = axios.create({
+  baseURL: '',
+  responseType: 'json',
+  headers: defaultHeaders,
+  timeout: REQUEST_TIMEOUT_MS
+});
+
+interface PropsInterface {
+  plugin: PluginInterface;
+}
+
+const SpaceTabEmulator: FC<PropsInterface> = ({plugin}) => {
+  console.log('RENDER SpaceEmulator', {plugin});
+  const theme = useTheme();
+  const coreProps: CorePluginPropsInterface = {
+    theme: theme as ThemeInterface,
+    isSpaceAdmin: false,
+    spaceId: '123',
+    request
+  };
+
+  const [topBar, setTopBar] = useState(<span />);
+
+  const renderTopBarActions = useCallback(
+    ({main}) => {
+      setTopBar(main());
+    },
+    [setTopBar]
+  );
+
+  return (
+    <div>
+      <styled.SpaceTopBar>
+        <strong>Space / Plugin</strong>
+        {topBar}
+      </styled.SpaceTopBar>
+      {!!plugin.SpaceExtension && (
+        <ErrorBoundary errorMessage="Error while rendering plugin">
+          <plugin.SpaceExtension renderTopBarActions={renderTopBarActions} {...coreProps} />
+        </ErrorBoundary>
+      )}
+    </div>
+  );
+};
+
+export const HostEmulator: FC<PropsInterface> = ({plugin}) => {
+  console.log('RENDER HostEmulator', {plugin});
+  const [tab, setTab] = useState('dash');
+  return (
+    <styled.SpaceLayout>
+      <styled.SpaceNav>
+        <styled.SpaceTab onClick={() => setTab('dash')}>Dashboard</styled.SpaceTab>
+        <styled.SpaceTab onClick={() => setTab('plugin')}>Plugin</styled.SpaceTab>
+      </styled.SpaceNav>
+      <styled.SpaceContent>
+        {tab === 'dash' && <div>Dashboard Content</div>}
+        {tab === 'plugin' && <SpaceTabEmulator plugin={plugin} />}
+      </styled.SpaceContent>
+    </styled.SpaceLayout>
+  );
+};

--- a/packages/sdk/src/emulator/index.ts
+++ b/packages/sdk/src/emulator/index.ts
@@ -1,0 +1,1 @@
+export * from './HostEmulator';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,4 @@
 export * from './contexts';
 export * from './interfaces';
 export * from './enums';
+export * from './emulator';


### PR DESCRIPTION
HostEmulator component is exported from sdk and provides a very simple visual implementation of the host.

It needs to be put into the plugin component, used for local development - done in plugin_miro.

#MIR-8
https://momentum.nifty.pm/l/JolUojT9ZF