### PR TITLE
feature(screensharing): relay call fixed

### DIFF
--- a/packages/app/src/scenes/collaboration/pages/ScreenSharePage/ScreenSharePage.tsx
+++ b/packages/app/src/scenes/collaboration/pages/ScreenSharePage/ScreenSharePage.tsx
@@ -36,8 +36,8 @@ const ScreenSharePage: FC = () => {
 
   const startScreenSharing = useCallback(async () => {
     const wasStarted: boolean = await agoraScreenShareStore.startScreenSharing(sessionStore.userId);
-    if (wasStarted) {
-      screenShareStore.relayScreenShare(space?.id ?? '');
+    if (wasStarted && space?.id) {
+      screenShareStore.relayScreenShare(space.id);
     }
   }, [agoraScreenShareStore, screenShareStore, sessionStore.userId, space?.id]);
 

--- a/packages/app/src/scenes/collaboration/pages/ScreenSharePage/ScreenSharePage.tsx
+++ b/packages/app/src/scenes/collaboration/pages/ScreenSharePage/ScreenSharePage.tsx
@@ -25,18 +25,21 @@ const ScreenSharePage: FC = () => {
 
   useEffect(() => {
     if (videoTrack) {
-      screenShareStore.relayScreenShare(space?.id ?? '');
-
-      const agoraUserId = videoTrack.getUserId() as string;
-      screenShareStore.setScreenOwner(agoraUserId);
+      const agoraUserId = videoTrack.getUserId()?.toString();
+      if (screenShareStore.screenOwnerId !== agoraUserId) {
+        screenShareStore.setScreenOwner(agoraUserId);
+      }
     } else {
       screenShareStore.setScreenOwner(null);
     }
   }, [videoTrack, screenShareStore, sessionStore.userId]);
 
-  const startScreenSharing = useCallback(() => {
-    agoraScreenShareStore.startScreenSharing(sessionStore.userId);
-  }, [agoraScreenShareStore, sessionStore.userId]);
+  const startScreenSharing = useCallback(async () => {
+    const wasStarted: boolean = await agoraScreenShareStore.startScreenSharing(sessionStore.userId);
+    if (wasStarted) {
+      screenShareStore.relayScreenShare(space?.id ?? '');
+    }
+  }, [agoraScreenShareStore, screenShareStore, sessionStore.userId, space?.id]);
 
   const stopScreenSharing = useCallback(() => {
     screenShareStore.setScreenOwner(null);

--- a/packages/app/src/stores/MainStore/models/AgoraStore/AgoraScreenShareStore/AgoraScreenShareStore.ts
+++ b/packages/app/src/stores/MainStore/models/AgoraStore/AgoraScreenShareStore/AgoraScreenShareStore.ts
@@ -81,6 +81,8 @@ const AgoraScreenShareStore = types
   }))
   .actions((self) => ({
     startScreenSharing: flow(function* (authStateSubject: string) {
+      let wasStarted = false;
+
       if (self.spaceId) {
         self.isSettingUp = true;
 
@@ -106,12 +108,15 @@ const AgoraScreenShareStore = types
         try {
           yield self.client.join(self.appId, token, response, `ss|${authStateSubject}`);
           yield self.createScreenTrackAndPublish();
+          wasStarted = true;
         } catch {
           self.client.leave();
         } finally {
           self.isSettingUp = false;
         }
       }
+
+      return wasStarted;
     }),
     stopScreenSharing() {
       if (!self.videoTrack) {


### PR DESCRIPTION
Relay function was called all the time when user went back to ScreenShare tab.
It cases getting events from controller and then all users redirects back to ScreenShare tab.
Relay function is called once after starting screensharing now.

[https://momentum.nifty.pm/l/RSwkdjdWExy](https://momentum.nifty.pm/l/RSwkdjdWExy)