### PR TITLE
Optimise git pre-commit hook by using eslint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.eslintcache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn run lint:errors
+yarn run lint:errors --cache
 yarn run prettier:fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn run lint:errors --cache
-yarn run prettier:fix
+yarn run prettier:fix --cache

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "private": true,
   "scripts": {
     "postinstall": "husky install",
-
     "build:deps": "yarn --cwd=packages/core build && yarn --cwd=packages/ui-kit build",
     "build": "yarn build:deps && yarn --cwd=packages/app build",
     "start": "yarn build:deps && yarn --cwd=packages/app start",
     "docker:build": "DOCKER_BUILDKIT=1 docker build -t ui-client:latest .",
-    "prettier": "prettier \"packages/**/*.{ts,tsx}\" --parser typescript",
+    "prettier": "prettier \"packages/*/src/**/*.{ts,tsx}\" --parser typescript",
     "prettier:list": "npm run prettier -- --list-different",
     "prettier:fix": "npm run prettier -- --write",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx packages/**/src",
@@ -32,5 +31,8 @@
     "styled-components": "^5.3.3",
     "@types/react": "^16.14.26",
     "@types/react-dom": "^16.9.11"
+  },
+  "devDependencies": {
+    "prettier": "^2.7.1"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -52,7 +52,6 @@
     "oidc-client": "^1.11.5",
     "oidc-client-ts": "^2.0.1",
     "polished": "^4.1.4",
-    "prettier": "^2.3.0",
     "rc-tooltip": "^5.1.1",
     "react": "^16.14.0",
     "react-add-to-calendar-hoc": "^1.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11156,10 +11156,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"


### PR DESCRIPTION
It should speed up the eslint pre-commit checks.