### PR TITLE
World builder - next step

### DIFF
--- a/packages/app/src/core/constants/routePaths.constants.ts
+++ b/packages/app/src/core/constants/routePaths.constants.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
     builder: {
       base: '/odyssey/:worldId/build',
       skybox: '/odyssey/:worldId/build/skybox',
+      editor: '/odyssey/:worldId/build/edit/:objectId',
       spawnAsset: {
         base: '/odyssey/:worldId/build/spawn',
         basicAssets: '/odyssey/:worldId/build/spawn/basic',

--- a/packages/app/src/core/constants/routePaths.constants.ts
+++ b/packages/app/src/core/constants/routePaths.constants.ts
@@ -9,7 +9,12 @@ export const ROUTES = {
     builder: {
       base: '/odyssey/:worldId/worldBuilder',
       skybox: '/odyssey/:worldId/worldBuilder/builderSkybox',
-      uploadAsset: '/odyssey/:worldId/worldBuilder/upload'
+      spawnAsset: {
+        base: '/odyssey/:worldId/worldBuilder/spawnAsset',
+        basicAssets: '/odyssey/:worldId/worldBuilder/spawnAsset/basic',
+        customAssets: '/odyssey/:worldId/worldBuilder/spawnAsset/custom',
+        uploadAsset: '/odyssey/:worldId/worldBuilder/spawnAsset/upload'
+      }
     },
     object: {
       root: '/odyssey/:worldId/object/:objectId',
@@ -54,6 +59,7 @@ export const ROUTES = {
     organisms: '/storybook/organisms'
   },
   worldBuilder: {
+    // TODO - remove
     base: '/createWorld',
     login: '/createWorld/login',
     start: '/createWorld/start',
@@ -63,11 +69,5 @@ export const ROUTES = {
     builder: '/worldBuilder',
     builderUploadAsset: '/worldBuilder/upload',
     builderSkybox: '/worldBuilder/skybox'
-  },
-  spawnAsset: {
-    base: '/spawnAsset/:worldId',
-    basicAssets: '/spawnAsset/:worldId/basic',
-    customAssets: '/spawnAsset/:worldId/custom',
-    uploadAsset: '/spawnAsset/:worldId/upload'
   }
 };

--- a/packages/app/src/core/constants/routePaths.constants.ts
+++ b/packages/app/src/core/constants/routePaths.constants.ts
@@ -7,13 +7,13 @@ export const ROUTES = {
   odyssey: {
     base: '/odyssey/:worldId',
     builder: {
-      base: '/odyssey/:worldId/worldBuilder',
-      skybox: '/odyssey/:worldId/worldBuilder/builderSkybox',
+      base: '/odyssey/:worldId/build',
+      skybox: '/odyssey/:worldId/build/skybox',
       spawnAsset: {
-        base: '/odyssey/:worldId/worldBuilder/spawnAsset',
-        basicAssets: '/odyssey/:worldId/worldBuilder/spawnAsset/basic',
-        customAssets: '/odyssey/:worldId/worldBuilder/spawnAsset/custom',
-        uploadAsset: '/odyssey/:worldId/worldBuilder/spawnAsset/upload'
+        base: '/odyssey/:worldId/build/spawn',
+        basicAssets: '/odyssey/:worldId/build/spawn/basic',
+        customAssets: '/odyssey/:worldId/build/spawn/custom',
+        uploadAsset: '/odyssey/:worldId/build/spawn/upload'
       }
     },
     object: {

--- a/packages/app/src/core/types/unityEvent.type.ts
+++ b/packages/app/src/core/types/unityEvent.type.ts
@@ -7,6 +7,7 @@ export type UnityEventType = {
   ExterminateUnity: (topic: string) => void;
   ClickEventDashboard: (id: string) => void;
   ClickEventVideo: (id: string) => void;
+  ClickEventEditableObject: (id: string) => void;
   PlasmaClickEvent: (id: string) => void;
   ProfileClickEvent: (id: string, position: UnityPositionInterface) => void;
   Error: (message: string) => void;

--- a/packages/app/src/scenes/App.routes.tsx
+++ b/packages/app/src/scenes/App.routes.tsx
@@ -18,7 +18,6 @@ const StoryBook = lazy(() => import('./storyBook/StoryBook'));
 const WorldBuilderCustomizePanel = lazy(
   () => import('./worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel')
 );
-const SpawnAsset = lazy(() => import('./worldBuilder/components/SpawnAsset/SpawnAsset'));
 
 export const SYSTEM_ROUTES: RouteConfigInterface[] = [
   {
@@ -102,10 +101,5 @@ export const PRIVATE_ROUTES_WITH_UNITY: RouteConfigInterface[] = [
     path: ROUTES.odyssey.object.root,
     renderBackground: false,
     main: () => <Object />
-  },
-  {
-    path: ROUTES.spawnAsset.base,
-    renderBackground: false,
-    main: () => <SpawnAsset />
   }
 ];

--- a/packages/app/src/scenes/unity/pages/UnityPage/UnityPage.tsx
+++ b/packages/app/src/scenes/unity/pages/UnityPage/UnityPage.tsx
@@ -110,6 +110,16 @@ const UnityPage: FC = () => {
     });
   });
 
+  useUnityEvent('ClickEventEditableObject', (spaceId: string) => {
+    console.log('ClickEventEditableObject', spaceId);
+    history.push({
+      pathname: generatePath(ROUTES.odyssey.builder.editor, {
+        worldId: worldStore.worldId,
+        objectId: spaceId
+      })
+    });
+  });
+
   usePosBusEvent('fly-to-me', (spaceId, userId, userName) => {
     if (sessionStore.userId === userId) {
       toast.info(

--- a/packages/app/src/scenes/unity/pages/UnityPage/components/atoms/PathObserver/PathObserver.tsx
+++ b/packages/app/src/scenes/unity/pages/UnityPage/components/atoms/PathObserver/PathObserver.tsx
@@ -42,10 +42,6 @@ const UNITY_ACTIVE_ROUTES: RouteConfigInterface[] = [
     path: ROUTES.odyssey.object.root,
     main: () => <></>,
     exact: false
-  },
-  {
-    path: ROUTES.spawnAsset.base,
-    main: () => <></>
   }
 ];
 

--- a/packages/app/src/scenes/widgets/Widgets.tsx
+++ b/packages/app/src/scenes/widgets/Widgets.tsx
@@ -2,7 +2,6 @@ import React, {FC, useEffect} from 'react';
 import {observer} from 'mobx-react-lite';
 import {useTranslation} from 'react-i18next';
 import {Avatar, ToolbarIcon, ToolbarIconList} from '@momentum-xyz/ui-kit';
-import {generatePath} from 'react-router-dom';
 
 import {useStore} from 'shared/hooks';
 import {ROUTES} from 'core/constants';
@@ -16,7 +15,8 @@ import {
   CalendarWidget,
   OnlineUsersWidget,
   NotificationsWidget,
-  OdysseyWidget
+  OdysseyWidget,
+  WorldBuilderWidget
 } from './pages';
 import * as styled from './Widgets.styled';
 
@@ -175,13 +175,7 @@ const Widgets: FC<PropsInterface> = (props) => {
                 state={{canGoBack: true}}
               />
 
-              <ToolbarIcon
-                title={t('titles.worldBuilder')}
-                icon="planet"
-                size="medium"
-                link={generatePath(ROUTES.spawnAsset.base, {worldId: worldStore.worldId})}
-                state={{canGoBack: true}}
-              />
+              <WorldBuilderWidget />
             </ToolbarIconList>
           </styled.RightToolbars>
         )}

--- a/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.styled.ts
+++ b/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.styled.ts
@@ -1,0 +1,27 @@
+import {rgba} from 'polished';
+import styled from 'styled-components';
+
+export const ActiveIconsContainer = styled.div`
+  display: flex;
+  gap: inherit;
+  height: 100%;
+  align-items: center;
+  padding: 0 14px;
+  border-radius: inherit;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  background: ${(props) => props.theme.accent && rgba(props.theme.accent, 0.25)};
+  position: relative;
+`;
+
+export const StandoutBuilderModeContainer = styled.div`
+  position: absolute;
+  right: 5px;
+  padding: 15px 30px;
+  bottom: 70px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 10px;
+  background: ${(props) => props.theme.accent && rgba(props.theme.accent, 0.35)};
+`;

--- a/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
@@ -1,0 +1,62 @@
+import {FC} from 'react';
+import {ToolbarIcon, ToolbarIconInterface} from '@momentum-xyz/ui-kit';
+import {generatePath, useLocation} from 'react-router-dom';
+
+import {ROUTES} from 'core/constants';
+import {useStore} from 'shared/hooks';
+
+const WorldBuilderWidget: FC = () => {
+  const {worldStore} = useStore().mainStore;
+
+  const collapsedItem: ToolbarIconInterface = {
+    title: 'World Builder',
+    icon: 'planet',
+    size: 'medium',
+    link: generatePath(ROUTES.odyssey.builder.spawnAsset.base, {worldId: worldStore.worldId})
+  };
+
+  const expandedItems: ToolbarIconInterface[] = [
+    {
+      title: 'Close World Builder',
+      icon: 'planet',
+      size: 'medium',
+      link: generatePath(ROUTES.odyssey.base, {worldId: worldStore.worldId})
+    },
+    {
+      title: 'Skybox',
+      icon: 'planet',
+      size: 'medium',
+      link: generatePath(ROUTES.odyssey.builder.skybox, {worldId: worldStore.worldId})
+    },
+    {
+      title: 'Upload',
+      icon: 'add',
+      size: 'medium',
+      link: generatePath(ROUTES.odyssey.builder.spawnAsset.base, {worldId: worldStore.worldId})
+    }
+    // {
+    //   title: 'Spawn Point',
+    //   icon: 'planet',
+    //   size: 'medium',
+    //   link: generatePath(ROUTES.odyssey.builder.spawnAsset.base, {worldId: worldStore.worldId})
+    // }
+  ];
+
+  const {pathname} = useLocation();
+
+  const isBuilderMode = pathname.includes(ROUTES.worldBuilder.builder);
+
+  if (isBuilderMode) {
+    return (
+      <>
+        {expandedItems.map((item) => (
+          <ToolbarIcon key={item.title} {...item} />
+        ))}
+      </>
+    );
+  }
+
+  return <ToolbarIcon {...collapsedItem} />;
+};
+
+export default WorldBuilderWidget;

--- a/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
@@ -1,9 +1,11 @@
 import {FC} from 'react';
-import {ToolbarIcon, ToolbarIconInterface} from '@momentum-xyz/ui-kit';
+import {ToolbarIcon, ToolbarIconInterface, Text, IconSvg} from '@momentum-xyz/ui-kit';
 import {generatePath, useLocation} from 'react-router-dom';
 
 import {ROUTES} from 'core/constants';
 import {useStore} from 'shared/hooks';
+
+import * as styled from './WorldBuilderWidget.styled';
 
 const WorldBuilderWidget: FC = () => {
   const {worldStore} = useStore().mainStore;
@@ -48,11 +50,20 @@ const WorldBuilderWidget: FC = () => {
 
   if (isBuilderMode) {
     return (
-      <>
+      <styled.ActiveIconsContainer>
         {expandedItems.map((item) => (
           <ToolbarIcon key={item.title} {...item} />
         ))}
-      </>
+        <styled.StandoutBuilderModeContainer>
+          <IconSvg name="planet" size="large" />
+          <Text
+            text="World Builder Mode Enabled"
+            size="xxs"
+            transform="uppercase"
+            isMultiline={false}
+          />
+        </styled.StandoutBuilderModeContainer>
+      </styled.ActiveIconsContainer>
     );
   }
 

--- a/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
@@ -20,7 +20,8 @@ const WorldBuilderWidget: FC = () => {
   const expandedItems: ToolbarIconInterface[] = [
     {
       title: 'Close World Builder',
-      icon: 'planet',
+      // icon: 'planet',
+      icon: 'close',
       size: 'medium',
       link: generatePath(ROUTES.odyssey.base, {worldId: worldStore.worldId})
     },

--- a/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
@@ -14,7 +14,7 @@ const WorldBuilderWidget: FC = () => {
     title: 'World Builder',
     icon: 'planet',
     size: 'medium',
-    link: generatePath(ROUTES.odyssey.builder.spawnAsset.base, {worldId: worldStore.worldId})
+    link: generatePath(ROUTES.odyssey.builder.base, {worldId: worldStore.worldId})
   };
 
   const expandedItems: ToolbarIconInterface[] = [

--- a/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/WorldBuilderWidget.tsx
@@ -46,7 +46,9 @@ const WorldBuilderWidget: FC = () => {
 
   const {pathname} = useLocation();
 
-  const isBuilderMode = pathname.includes(ROUTES.worldBuilder.builder);
+  const isBuilderMode = pathname.includes(
+    generatePath(ROUTES.odyssey.builder.base, {worldId: worldStore.worldId})
+  );
 
   if (isBuilderMode) {
     return (

--- a/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/index.ts
+++ b/packages/app/src/scenes/widgets/pages/WorldBuilderWidget/index.ts
@@ -1,0 +1,1 @@
+export {default as WorldBuilderWidget} from './WorldBuilderWidget';

--- a/packages/app/src/scenes/widgets/pages/index.ts
+++ b/packages/app/src/scenes/widgets/pages/index.ts
@@ -8,3 +8,4 @@ export * from './SocialWidget';
 export * from './NotificationsWidget';
 export * from './CalendarWidget';
 export * from './OdysseyWidget';
+export * from './WorldBuilderWidget';

--- a/packages/app/src/scenes/worldBuilder/components/SpawnAsset/SpawnAsset.routes.tsx
+++ b/packages/app/src/scenes/worldBuilder/components/SpawnAsset/SpawnAsset.routes.tsx
@@ -5,15 +5,15 @@ import {BasicAssetsPackPage, CustomAssetsLibraryPage, UploadCustomAssetPage} fro
 
 export const SPAWN_ASSET_ROUTES: RouteConfigInterface[] = [
   {
-    path: ROUTES.spawnAsset.basicAssets,
+    path: ROUTES.odyssey.builder.spawnAsset.basicAssets,
     main: () => <BasicAssetsPackPage />
   },
   {
-    path: ROUTES.spawnAsset.customAssets,
+    path: ROUTES.odyssey.builder.spawnAsset.customAssets,
     main: () => <CustomAssetsLibraryPage />
   },
   {
-    path: ROUTES.spawnAsset.uploadAsset,
+    path: ROUTES.odyssey.builder.spawnAsset.uploadAsset,
     main: () => <UploadCustomAssetPage />
   }
 ];

--- a/packages/app/src/scenes/worldBuilder/components/SpawnAsset/SpawnAsset.tsx
+++ b/packages/app/src/scenes/worldBuilder/components/SpawnAsset/SpawnAsset.tsx
@@ -29,7 +29,7 @@ const SpawnAsset: FC = () => {
           <styled.PageContainer>
             {createSwitchByConfig(
               SPAWN_ASSET_ROUTES,
-              generatePath(ROUTES.spawnAsset.basicAssets, {worldId})
+              generatePath(ROUTES.odyssey.builder.spawnAsset.basicAssets, {worldId})
             )}
           </styled.PageContainer>
         </styled.Body>

--- a/packages/app/src/scenes/worldBuilder/components/SpawnAsset/SpawnAsset.tsx
+++ b/packages/app/src/scenes/worldBuilder/components/SpawnAsset/SpawnAsset.tsx
@@ -21,7 +21,7 @@ const SpawnAsset: FC = () => {
           <SvgButton
             iconName="close"
             size="medium-large"
-            onClick={() => history.push(generatePath(ROUTES.odyssey.base, {worldId}))}
+            onClick={() => history.push(generatePath(ROUTES.odyssey.builder.base, {worldId}))}
           />
         </styled.Header>
         <styled.Body>

--- a/packages/app/src/scenes/worldBuilder/components/SpawnAsset/components/SpawnAssetMenu/SpawnAssetMenu.tsx
+++ b/packages/app/src/scenes/worldBuilder/components/SpawnAsset/components/SpawnAssetMenu/SpawnAssetMenu.tsx
@@ -19,25 +19,34 @@ const SpawnAssetMenu: FC<PropsInterface> = ({worldId}) => {
     <styled.Container>
       <styled.Tab
         className={cn(
-          matchPath(location.pathname, {path: ROUTES.spawnAsset.basicAssets}) && 'selected'
+          matchPath(location.pathname, {path: ROUTES.odyssey.builder.spawnAsset.basicAssets}) &&
+            'selected'
         )}
-        onClick={() => history.push(generatePath(ROUTES.spawnAsset.basicAssets, {worldId}))}
+        onClick={() =>
+          history.push(generatePath(ROUTES.odyssey.builder.spawnAsset.basicAssets, {worldId}))
+        }
       >
         <Text text="Basic Asset Pack" size="l" weight="light" align="left" />
       </styled.Tab>
       <styled.Tab
         className={cn(
-          matchPath(location.pathname, {path: ROUTES.spawnAsset.customAssets}) && 'selected'
+          matchPath(location.pathname, {path: ROUTES.odyssey.builder.spawnAsset.customAssets}) &&
+            'selected'
         )}
-        onClick={() => history.push(generatePath(ROUTES.spawnAsset.customAssets, {worldId}))}
+        onClick={() =>
+          history.push(generatePath(ROUTES.odyssey.builder.spawnAsset.customAssets, {worldId}))
+        }
       >
         <Text text="Custom Object Library" size="l" weight="light" align="left" />
       </styled.Tab>
       <styled.Tab
         className={cn(
-          matchPath(location.pathname, {path: ROUTES.spawnAsset.uploadAsset}) && 'selected'
+          matchPath(location.pathname, {path: ROUTES.odyssey.builder.spawnAsset.uploadAsset}) &&
+            'selected'
         )}
-        onClick={() => history.push(generatePath(ROUTES.spawnAsset.uploadAsset, {worldId}))}
+        onClick={() =>
+          history.push(generatePath(ROUTES.odyssey.builder.spawnAsset.uploadAsset, {worldId}))
+        }
       >
         <Text text="Upload Custom Object" size="l" weight="light" align="left" />
       </styled.Tab>

--- a/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.routes.tsx
+++ b/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.routes.tsx
@@ -5,6 +5,11 @@ import {SkyboxSelectorWithPreview} from '../../components';
 
 export const WORLD_BUILDER_ROUTES = [
   {
+    path: ROUTES.odyssey.builder.base,
+    main: () => <></>,
+    exact: true
+  },
+  {
     path: ROUTES.odyssey.builder.skybox,
     main: () => <SkyboxSelectorWithPreview />,
     exact: true

--- a/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.routes.tsx
+++ b/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.routes.tsx
@@ -18,5 +18,10 @@ export const WORLD_BUILDER_ROUTES = [
     path: ROUTES.odyssey.builder.spawnAsset.base,
     main: () => <SpawnAsset />,
     exact: false
+  },
+  {
+    path: ROUTES.odyssey.builder.editor,
+    main: () => <div style={{background: 'white', padding: '1em'}}>TODO EDITOR</div>,
+    exact: false
   }
 ];

--- a/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.routes.tsx
+++ b/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.routes.tsx
@@ -1,6 +1,7 @@
 import {ROUTES} from 'core/constants';
+import {SpawnAsset} from 'scenes/worldBuilder/components/SpawnAsset';
 
-import {SkyboxSelectorWithPreview, UploadAsset} from '../../components';
+import {SkyboxSelectorWithPreview} from '../../components';
 
 export const WORLD_BUILDER_ROUTES = [
   {
@@ -9,8 +10,8 @@ export const WORLD_BUILDER_ROUTES = [
     exact: true
   },
   {
-    path: ROUTES.odyssey.builder.uploadAsset,
-    main: () => <UploadAsset />,
-    exact: true
+    path: ROUTES.odyssey.builder.spawnAsset.base,
+    main: () => <SpawnAsset />,
+    exact: false
   }
 ];

--- a/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.tsx
+++ b/packages/app/src/scenes/worldBuilder/pages/WorldBuilderCustomizePanel/WorldBuilderCustomizePanel.tsx
@@ -1,65 +1,23 @@
-import {FC} from 'react';
+import {FC, useEffect} from 'react';
 import {observer} from 'mobx-react-lite';
-// import {useTranslation} from 'react-i18next';
-import {useTheme} from 'styled-components';
-import {
-  Dialog,
-  Navigation,
-  NavigationTabInterface
-  // Loader
-} from '@momentum-xyz/ui-kit';
-import {generatePath, useHistory} from 'react-router-dom';
 
-// import {useStore} from 'shared/hooks';
 import {useStore} from 'shared/hooks';
-import {ROUTES} from 'core/constants';
 import {createSwitchByConfig} from 'core/utils';
 
-import * as styled from './WorldBuilderCustomizePanel.styled';
 import {WORLD_BUILDER_ROUTES} from './WorldBuilderCustomizePanel.routes';
 
 const WorldBuilderCustomizePanel: FC = () => {
   const {mainStore} = useStore();
-  const {worldStore} = mainStore;
+  const {unityStore} = mainStore;
 
-  const history = useHistory();
+  useEffect(() => {
+    unityStore.toggleBuildMode();
+    return () => {
+      unityStore.toggleBuildMode();
+    };
+  }, [unityStore]);
 
-  // const {t} = useTranslation();
-  const theme = useTheme();
-
-  const tabs: NavigationTabInterface[] = [
-    {
-      path: generatePath(ROUTES.odyssey.builder.skybox, {worldId: worldStore.worldId}),
-      iconName: 'planet'
-    },
-    {
-      path: generatePath(ROUTES.odyssey.builder.uploadAsset, {worldId: worldStore.worldId}),
-      iconName: 'add'
-    }
-  ];
-
-  // const handleSearchFocus = (isFocused: boolean) => {
-  //   unityStore.changeKeyboardControl(!isFocused);
-  // };
-
-  return (
-    <Dialog
-      theme={theme}
-      // title="World Builder Menu"
-      // headerStyle="uppercase"
-      showBackground={false}
-      showCloseButton
-      // showOverflow
-      // withOpacity
-      isBodyExtendingToEdges
-      onClose={() => history.push(generatePath(ROUTES.odyssey.base, {worldId: worldStore.worldId}))}
-    >
-      <styled.Container>
-        <Navigation tabs={tabs} />
-        {createSwitchByConfig(WORLD_BUILDER_ROUTES, WORLD_BUILDER_ROUTES[0].path)}
-      </styled.Container>
-    </Dialog>
-  );
+  return <>{createSwitchByConfig(WORLD_BUILDER_ROUTES, WORLD_BUILDER_ROUTES[0].path)}</>;
 };
 
 export default observer(WorldBuilderCustomizePanel);

--- a/packages/app/src/shared/services/unity/UnityService.tsx
+++ b/packages/app/src/shared/services/unity/UnityService.tsx
@@ -11,6 +11,7 @@ export class UnityService {
   unityApi?: UnityApiInterface;
   unityContext?: UnityContext;
   isPaused = false;
+  isBuildMode = false;
 
   getCurrentWorld?: () => void;
   getUserPosition?: () => void;
@@ -70,6 +71,12 @@ export class UnityService {
 
     this.unityContext.on('ClickEvent', (identifier: string) => {
       const [type, id] = identifier.split('|');
+
+      if (this.isBuildMode) {
+        UnityEventEmitter.emit('ClickEventEditableObject', id);
+        return;
+      }
+
       if (type === 'video') {
         UnityEventEmitter.emit('ClickEventVideo', id);
       } else {
@@ -238,6 +245,7 @@ export class UnityService {
 
   toggleBuildMode() {
     this.unityApi?.toggleBuildMode();
+    this.isBuildMode = !this.isBuildMode;
   }
 
   leaveSpace(id: string) {


### PR DESCRIPTION
I changed the routes a little bit to fit the new structure.

SpawnAsset now goes to `/odyssey/:worldId/build/spawn` and gets instantiated by `WorldBuilderCustomizePanel`. Same goes for Skyboxes selector and the rest.

It's needed in order to enable global builder mode in unity and our app.

By default builder mode shows only unity gizmo panel and free space allowing to fly around and select objects - in builder mode we're supposed to handle the click on editable objects in 3d space and show gizmo (it's unity logic). Added a placeholder for the interface that will handle editing these objects.

Added also World Builder widget - in builder route it expands and show kind of nav panel allowing selection of skybox, spawn and closing build mode.