### PR TITLE
feat(nft-staking-styles): Dashboard active stakes alignment

### DIFF
--- a/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.styled.ts
+++ b/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.styled.ts
@@ -91,6 +91,7 @@ export const ActiveStakesLineContainer = styled.div`
 
   & > * {
     flex: 1;
+    padding-right: 5px;
   }
 
   & > button {

--- a/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.styled.ts
+++ b/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.styled.ts
@@ -92,6 +92,12 @@ export const ActiveStakesLineContainer = styled.div`
   & > * {
     flex: 1;
     padding-right: 5px;
+
+    &.name {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
   }
 
   & > button {

--- a/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.styled.ts
+++ b/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.styled.ts
@@ -89,7 +89,12 @@ export const ActiveStakesLineContainer = styled.div`
   justify-content: space-between;
   padding: 0 10px;
 
-  & button {
+  & > * {
+    flex: 1;
+  }
+
+  & > button {
+    flex: 0 95px;
     flex-direction: row-reverse;
     border: none;
     color: white !important;

--- a/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.tsx
+++ b/packages/app/src/scenes/explore/pages/ExplorePage/components/organisms/StakingDashboard/StakingDashboard.tsx
@@ -181,6 +181,7 @@ const StakingDashboard: FC<PropsInterface> = ({onComplete}) => {
                           size="s"
                           text={nft?.name || stakingDetail.sourceAddr.substring(0, 20)}
                           align="left"
+                          className="name"
                         />
                         <Text
                           size="s"


### PR DESCRIPTION
Updated the styles of the dashboard active stakes so that they align properly:
<img width="534" alt="image" src="https://user-images.githubusercontent.com/9742836/207038397-0b0491ff-13d8-484d-9a46-f480b4201570.png">


Not sure how it's intended to handle extra long names. At the moment it does this:
<img width="530" alt="image" src="https://user-images.githubusercontent.com/9742836/207039132-822534a0-cc08-470e-9feb-ace53b8a4a2a.png">
