### PR TITLE
feat(creator): skybox preview images

### DIFF
--- a/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.types.ts
+++ b/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.types.ts
@@ -19,7 +19,7 @@ export interface Asset3dMetadataInterface {
   name: string;
   type: number;
   category: Asset3dCategoryEnum;
-  previewImage?: string;
+  preview_hash?: string;
 }
 
 export interface Asset3dInterface {

--- a/packages/app/src/scenes/odysseyCreator/stores/SkyboxSelectorStore/SkyboxSelectorStore.ts
+++ b/packages/app/src/scenes/odysseyCreator/stores/SkyboxSelectorStore/SkyboxSelectorStore.ts
@@ -1,5 +1,6 @@
 import {cast, flow, types} from 'mobx-state-tree';
 import {RequestModel, ResetModel} from '@momentum-xyz/core';
+import {ImageSizeEnum} from '@momentum-xyz/ui-kit';
 import {AttributeNameEnum} from '@momentum-xyz/sdk';
 
 import {Asset3d, Asset3dInterface} from 'core/models';
@@ -33,13 +34,13 @@ const SkyboxSelectorStore = types
       }
 
       const skyboxes =
-        assets3d.map(({id, meta: {name, previewImage}}) => ({
+        assets3d.map(({id, meta: {name, preview_hash}}) => ({
           id,
           name,
           image:
             // FIXME - temp until proper preview images are available
-            previewImage
-              ? `${appVariables.RENDER_SERVICE_URL}/get/${previewImage}`
+            preview_hash
+              ? `${appVariables.RENDER_SERVICE_URL}/texture/${ImageSizeEnum.S3}/${preview_hash}`
               : 'https://dev.odyssey.ninja/api/v3/render/get/03ce359d18bfc0fe977bd66ab471d222'
         })) || [];
 

--- a/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
+++ b/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
@@ -1,5 +1,6 @@
 import {cast, flow, types} from 'mobx-state-tree';
 import {RequestModel, ResetModel} from '@momentum-xyz/core';
+import {ImageSizeEnum} from '@momentum-xyz/ui-kit';
 import {SpaceSubOptionKeyEnum} from '@momentum-xyz/sdk';
 
 import {api, FetchAssets3dResponse, PostSpaceResponse, UploadAsset3dRequest} from 'api';
@@ -92,13 +93,13 @@ const SpawnAssetStore = types
 
       if (response) {
         const assets =
-          response.map(({id, meta: {name, previewImage}}) => ({
+          response.map(({id, meta: {name, preview_hash}}) => ({
             id,
             name,
             image:
               // FIXME - temp until proper preview images are available
-              previewImage
-                ? `${appVariables.RENDER_SERVICE_URL}/get/${previewImage}`
+              preview_hash
+                ? `${appVariables.RENDER_SERVICE_URL}/texture/${ImageSizeEnum.S3}/${preview_hash}`
                 : 'https://dev.odyssey.ninja/api/v3/render/get/03ce359d18bfc0fe977bd66ab471d222'
           })) || [];
 


### PR DESCRIPTION
Was named preview_hash in the backend JSON, to match render_hash that was already used in other places.