### PR TITLE
Packages scripts improvements

### DIFF
--- a/packages/map3d/package.json
+++ b/packages/map3d/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "yarn clean && tsc --listEmittedFiles && yarn copy-files",
-    "start": "yarn clean && yarn copy-files && tsc -w",
+    "start": "yarn copy-files && tsc -w",
     "copy-files": "copyfiles -u 1 src/static/**/*.* dist/"
   },
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -13,7 +13,7 @@
     "copy-files": "copyfiles -u 1 bin/*.js dist/bin && copyfiles craco.config.js dist/",
     "clean": "rimraf dist/",
     "build": "yarn workspace @momentum-xyz/ui-kit build && yarn clean && yarn copy-files && tsc --listEmittedFiles",
-    "start": "tsc -w"
+    "start": "yarn copy-files && tsc -w"
   },
   "dependencies": {
     "@momentum-xyz/ui-kit": "^0.1.3",

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "yarn clean && tsc --listEmittedFiles && yarn copy-files",
-    "start": "yarn clean && yarn copy-files && tsc -w",
+    "start": "yarn copy-files && tsc -w",
     "copy-files": "copyfiles -u 1 src/**/*.svg dist/",
     "svg-sprite:build": "node scripts/buildSvgSprite.js",
     "svg-sprite:type": "node scripts/generateIconsType.js"


### PR DESCRIPTION
It's a small change making working with modules like ui-kit, sdk, core easier - don't clear files in yarn-start, just copy-files and run tsc watch.

When app is started and then you make a change in some module like ui-kit - yarn-start used to remove previously built files before running tsc watch making us restart app's yarn start. It's better without it and if someone needs it, just execute yarn-clean