### PR TITLE
feat(api): backend api urls with portnumbers

### DIFF
--- a/packages/app/src/api/repositories/agoraRepository/agoraRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/agoraRepository/agoraRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const agoraRepositoryApiEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/spaces`;
+  const BASE_URL = '/spaces';
 
   return {
     token: `${BASE_URL}/:spaceId/agora/token`

--- a/packages/app/src/api/repositories/assets2dRepository/assets2dRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/assets2dRepository/assets2dRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const assets2dRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/assets-2d`;
+  const BASE_URL = '/assets-2d';
 
   return {
     asset: `${BASE_URL}/:assetId`

--- a/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const assets3dRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/assets-3d/:worldId`;
+  const BASE_URL = '/assets-3d/:worldId';
 
   return {
     base: BASE_URL,

--- a/packages/app/src/api/repositories/authRepository/authRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/authRepository/authRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const authRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/auth`;
+  const BASE_URL = '/auth';
 
   return {
     challenge: `${BASE_URL}/challenge`,

--- a/packages/app/src/api/repositories/configRepository/configRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/configRepository/configRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const configRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/config`;
+  const BASE_URL = '/config';
 
   return {
     config: `${BASE_URL}/ui-client`

--- a/packages/app/src/api/repositories/feedRepository/feedRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/feedRepository/feedRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const feedRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}`;
+  const BASE_URL = '';
 
   return {
     feed: `${BASE_URL}/newsfeed`,

--- a/packages/app/src/api/repositories/flightRepository/flightRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/flightRepository/flightRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const flightRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/worlds/:spaceId`;
+  const BASE_URL = '/worlds/:spaceId';
 
   return {
     startFlyWithMe: `${BASE_URL}/fly-with-me/start`,

--- a/packages/app/src/api/repositories/mediaRepository/mediaRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/mediaRepository/mediaRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const mediaRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/media/upload`;
+  const BASE_URL = '/media/upload';
 
   return {
     uploadImage: `${BASE_URL}/image`

--- a/packages/app/src/api/repositories/pluginsRepository/pluginsRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/pluginsRepository/pluginsRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const pluginsRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/plugins`;
+  const BASE_URL = '/plugins';
 
   return {
     list: `${BASE_URL}`,

--- a/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttribute.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttribute.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const spaceAttributesRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/spaces/:spaceId/attributes`;
+  const BASE_URL = '/spaces/:spaceId/attributes';
 
   return {
     attributes: `${BASE_URL}`,

--- a/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const spaceInfoRepository = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/spaces`;
+  const BASE_URL = '/spaces';
 
   return {
     spaceInfo: `${BASE_URL}/:spaceId`

--- a/packages/app/src/api/repositories/spaceOptionRepository/spaceOptionRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceOptionRepository/spaceOptionRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const spaceOptionRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/spaces/:spaceId`;
+  const BASE_URL = '/spaces/:spaceId';
 
   return {
     options: `${BASE_URL}/options`,

--- a/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const spaceRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/spaces`;
+  const BASE_URL = '/spaces';
 
   return {
     base: `${BASE_URL}`,

--- a/packages/app/src/api/repositories/spaceUserAttributeRepository/spaceUserAttributeRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceUserAttributeRepository/spaceUserAttributeRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const spaceUserAttributeRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/spaces`;
+  const BASE_URL = '/spaces';
 
   return {
     attribute: `${BASE_URL}/:spaceId/:userId/attributes`,

--- a/packages/app/src/api/repositories/streamChatRepository/streamChatRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/streamChatRepository/streamChatRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const streamChatRepositoryApiEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/streamchat`;
+  const BASE_URL = '/streamchat';
 
   return {
     baseURL: BASE_URL,

--- a/packages/app/src/api/repositories/userAttributeRepository/userAttributeRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/userAttributeRepository/userAttributeRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const spaceUserAttributesRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/worlds/:worldId/users/:userId/attributes`;
+  const BASE_URL = '/worlds/:worldId/users/:userId/attributes';
 
   return {
     pluginAttributes: `${BASE_URL}/:pluginId`,

--- a/packages/app/src/api/repositories/userProfileRepository/userProfileRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/userProfileRepository/userProfileRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const userRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/profile`;
+  const BASE_URL = '/profile';
 
   return {
     base: BASE_URL

--- a/packages/app/src/api/repositories/userRepository/userRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/userRepository/userRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const userRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/users`;
+  const BASE_URL = '/users';
 
   return {
     me: `${BASE_URL}/me`,

--- a/packages/app/src/api/repositories/web3Repository/web3Repository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/web3Repository/web3Repository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const web3RepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/drive`;
+  const BASE_URL = '/drive';
 
   return {
     mintNft: `${BASE_URL}/mint-odyssey`,

--- a/packages/app/src/api/repositories/worldRepository/worldRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/worldRepository/worldRepository.api.endpoints.ts
@@ -1,7 +1,5 @@
-import {appVariables} from 'api/constants';
-
 export const worldRepositoryEndpoints = () => {
-  const BASE_URL = `${appVariables.BACKEND_API_URL}/worlds/:worldId`;
+  const BASE_URL = '/worlds/:worldId';
 
   return {
     getSpaceWithSubspaces: `${BASE_URL}/explore`,

--- a/packages/app/src/api/request/request.ts
+++ b/packages/app/src/api/request/request.ts
@@ -1,6 +1,6 @@
 import axios, {AxiosInstance, AxiosResponse, AxiosRequestConfig, AxiosError} from 'axios';
 
-import {httpErrorCodes} from 'api/constants';
+import {appVariables, httpErrorCodes} from 'api/constants';
 
 const TOKEN_TYPE = 'Bearer';
 const TOKEN_KEY = 'odyssey.token';
@@ -16,7 +16,6 @@ const defaultHeaders: Record<string, string> = {
  * Create a new Axios instance with a custom config.
  */
 const request: AxiosInstance = axios.create({
-  baseURL: '',
   responseType: 'json',
   headers: defaultHeaders,
   timeout: REQUEST_TIMEOUT_MS
@@ -26,6 +25,7 @@ const request: AxiosInstance = axios.create({
  * Create request, response & error handlers
  */
 const requestHandler = (requestConfig: AxiosRequestConfig & {authToken?: string}) => {
+  requestConfig.baseURL = `${appVariables.BACKEND_API_URL}`;
   if (requestConfig.authToken && requestConfig.headers) {
     /** set authToken provided by the app */
     requestConfig.headers.Authorization = `${TOKEN_TYPE} ${requestConfig.authToken}`;


### PR DESCRIPTION
Fix working with backend api urls like "http://localhost:4000".

generatePath function is used on the whole URL. But, like the name suggests, this is suppoed to only be used on the path of an URL. Otherwise in case if "http://locahost:3000" :3000 is seen as a path parameter and will throw an error since no param with the name '3000' is passed into it.

Moved the scheme+domain to where the request is created. If a request is made with an absolute URL this is not used, so e.g. the /version api repository, which uses a different url prefix, still works.