### PR TITLE
fix TestnetMark: show on all pages including signIn

### DIFF
--- a/packages/app/src/scenes/App.tsx
+++ b/packages/app/src/scenes/App.tsx
@@ -21,6 +21,7 @@ import {
 import AppAuth from './AppAuth';
 import AppLayers from './AppLayers';
 import {GlobalStyles} from './App.styled';
+import {TestnetMarkWidget} from './widgets/pages';
 
 import 'react-notifications/lib/notifications.css';
 import 'react-toastify/dist/ReactToastify.css';
@@ -93,6 +94,7 @@ const App: FC = () => {
     return (
       <ThemeProvider theme={themeStore.theme}>
         <Suspense fallback={false}>{createSwitchByConfig(SYSTEM_ROUTES)}</Suspense>
+        <TestnetMarkWidget withOffset />
       </ThemeProvider>
     );
   }
@@ -116,6 +118,7 @@ const App: FC = () => {
       <ThemeProvider theme={themeStore.theme}>
         <GlobalStyles />
         <Suspense fallback={false}>{createSwitchByConfig(PUBLIC_ROUTES)}</Suspense>
+        <TestnetMarkWidget />
       </ThemeProvider>
     );
   }
@@ -129,6 +132,7 @@ const App: FC = () => {
           <UnityPage />
           <Suspense fallback={false}>
             <AppLayers renderUnity>{createSwitchByConfig(PRIVATE_ROUTES_WITH_UNITY)}</AppLayers>
+            <TestnetMarkWidget withOffset />
           </Suspense>
         </AppAuth>
       </ThemeProvider>
@@ -142,6 +146,7 @@ const App: FC = () => {
         <AppAuth>
           <GlobalStyles />
           <AppLayers>{createSwitchByConfig(PRIVATE_ROUTES, ROUTES.explore)}</AppLayers>
+          <TestnetMarkWidget />
         </AppAuth>
       </Suspense>
     </ThemeProvider>

--- a/packages/app/src/scenes/AppLayers.tsx
+++ b/packages/app/src/scenes/AppLayers.tsx
@@ -6,8 +6,6 @@ import {useTheme} from 'styled-components';
 import {useStore} from 'shared/hooks';
 import {ToastMessage} from 'ui-kit';
 
-import {TestnetMarkWidget} from './widgets/pages';
-
 const Widgets = lazy(() => import('./widgets/Widgets'));
 
 interface PropsInterface {
@@ -27,7 +25,7 @@ const AppLayers: FC<PropsInterface> = (props) => {
   return (
     <div data-testid="AppLayers-test">
       <ToastMessage position={toast.POSITION.BOTTOM_RIGHT} theme={theme} />
-      <TestnetMarkWidget withOffset={renderUnity} />
+
       {renderUnity && <Widgets />}
       <main id="main">
         <div className="main-content">{children}</div>


### PR DESCRIPTION
It wasn't shown on the pages rendered before user sign-in.