### PR TITLE
Handle max model size error in Asset Upload

### DIFF
--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
@@ -57,6 +57,14 @@ const UploadCustomAssetPage: FC = () => {
 
             setAsset(file);
           }}
+          onError={(err) => {
+            console.log('File upload error:', err, err.message);
+            if (err.message === 'FileSizeTooLarge') {
+              setError(t('assetsUploader.errorTooLargeFile'));
+            } else {
+              setError(t('assetsUploader.errorSave'));
+            }
+          }}
           label={t('actions.uploadYourAssset')}
           dragActiveLabel={t('actions.dropItHere')}
           fileType={'' as FileType}
@@ -82,7 +90,7 @@ const UploadCustomAssetPage: FC = () => {
           <Button
             label={t('actions.addToLibrary')}
             onClick={handleAddToLbrary}
-            disabled={!spawnAssetStore.uploadedAssetName}
+            disabled={!spawnAssetStore.uploadedAssetName || !!error}
           />
         </>
       )}

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
@@ -11,6 +11,7 @@ import {ToastContent} from 'ui-kit';
 import * as styled from './UploadCustomAssetPage.styled';
 
 const MAX_ASSET_SIZE = 50_100_000;
+const MAX_ASSET_SIZE_MB = `${(MAX_ASSET_SIZE / 1_000_000).toFixed(1)}MB`;
 
 const UploadCustomAssetPage: FC = () => {
   const {odysseyCreatorStore, unityStore} = useStore();
@@ -45,6 +46,7 @@ const UploadCustomAssetPage: FC = () => {
   return (
     <styled.Container>
       <Text text={t('messages.weSupportGLBModels')} size="m" />
+      <Text text={t('messages.glbModelsMaxSize', {size: MAX_ASSET_SIZE_MB})} size="m" />
       <styled.FileUploaderContainer>
         <FileUploader
           onFilesUpload={(file) => {
@@ -60,7 +62,7 @@ const UploadCustomAssetPage: FC = () => {
           onError={(err) => {
             console.log('File upload error:', err, err.message);
             if (err.message === 'FileSizeTooLarge') {
-              setError(t('assetsUploader.errorTooLargeFile'));
+              setError(t('assetsUploader.errorTooLargeFile', {size: MAX_ASSET_SIZE_MB}));
             } else {
               setError(t('assetsUploader.errorSave'));
             }

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
@@ -11,7 +11,7 @@ import {ToastContent} from 'ui-kit';
 import * as styled from './UploadCustomAssetPage.styled';
 
 const MAX_ASSET_SIZE = 50_100_000;
-const MAX_ASSET_SIZE_MB = `${(MAX_ASSET_SIZE / 1_000_000).toFixed(1)}MB`;
+const MAX_ASSET_SIZE_MB = `${(MAX_ASSET_SIZE / 1_000_000).toFixed(1)}`;
 
 const UploadCustomAssetPage: FC = () => {
   const {odysseyCreatorStore, unityStore} = useStore();

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
@@ -1,4 +1,4 @@
-import {Button, FileType, FileUploader, Text} from '@momentum-xyz/ui-kit';
+import {Button, ErrorsEnum, FileType, FileUploader, Text} from '@momentum-xyz/ui-kit';
 import {Model3dPreview} from '@momentum-xyz/map3d';
 import {observer} from 'mobx-react-lite';
 import {FC, useCallback, useState, useEffect} from 'react';
@@ -61,7 +61,7 @@ const UploadCustomAssetPage: FC = () => {
           }}
           onError={(err) => {
             console.log('File upload error:', err, err.message);
-            if (err.message === 'FileSizeTooLarge') {
+            if (err.message === ErrorsEnum.FileSizeTooLarge) {
               setError(t('assetsUploader.errorTooLargeFile', {size: MAX_ASSET_SIZE_MB}));
             } else {
               setError(t('assetsUploader.errorSave'));

--- a/packages/app/src/shared/services/i18n/locales/en-gb.ts
+++ b/packages/app/src/shared/services/i18n/locales/en-gb.ts
@@ -444,6 +444,7 @@ export const enGb = {
       errorWhileRemovingPlugin:
         'Error has occured when removing {{pluginName}} removed succesfully!',
       weSupportGLBModels: 'We support GLB Models',
+      glbModelsMaxSize: '(max file size {{size}})',
       selectOne: 'Select One',
       processing: 'Processing',
       comingSoonExclamation: 'Coming Soon!',
@@ -665,7 +666,7 @@ export const enGb = {
       spaceName: 'Space Name',
       successMessage: 'Asset successfully uploaded',
       errorUnsupportedFile: 'Only .glb files are supported',
-      errorTooLargeFile: 'Max file size is 50.1MB',
+      errorTooLargeFile: 'Max file size is {{size}}',
       errorSave: 'Error uploading asset'
     },
     eventList: {

--- a/packages/app/src/shared/services/i18n/locales/en-gb.ts
+++ b/packages/app/src/shared/services/i18n/locales/en-gb.ts
@@ -444,7 +444,7 @@ export const enGb = {
       errorWhileRemovingPlugin:
         'Error has occured when removing {{pluginName}} removed succesfully!',
       weSupportGLBModels: 'We support GLB Models',
-      glbModelsMaxSize: '(max file size {{size}})',
+      glbModelsMaxSize: '(max file size {{size}}MB)',
       selectOne: 'Select One',
       processing: 'Processing',
       comingSoonExclamation: 'Coming Soon!',
@@ -666,7 +666,7 @@ export const enGb = {
       spaceName: 'Space Name',
       successMessage: 'Asset successfully uploaded',
       errorUnsupportedFile: 'Only .glb files are supported',
-      errorTooLargeFile: 'Max file size is {{size}}',
+      errorTooLargeFile: 'Max file size is {{size}}MB',
       errorSave: 'Error uploading asset'
     },
     eventList: {

--- a/packages/ui-kit/src/enums/errors.enum.ts
+++ b/packages/ui-kit/src/enums/errors.enum.ts
@@ -1,0 +1,3 @@
+export enum ErrorsEnum {
+  FileSizeTooLarge = 'FileSizeTooLarge'
+}

--- a/packages/ui-kit/src/enums/index.ts
+++ b/packages/ui-kit/src/enums/index.ts
@@ -1,2 +1,3 @@
 export * from './userStatus.enum';
 export * from './imageSize.enum';
+export * from './errors.enum';

--- a/packages/ui-kit/src/molecules/FileUploader/FileUploader.tsx
+++ b/packages/ui-kit/src/molecules/FileUploader/FileUploader.tsx
@@ -4,6 +4,7 @@ import {useDropzone} from 'react-dropzone';
 import {PropsWithThemeInterface} from '../../interfaces';
 import {FileType} from '../../types';
 import {Button} from '../../atoms';
+import {ErrorsEnum} from '../../enums';
 
 import * as styled from './FileUploader.styled';
 
@@ -45,7 +46,7 @@ const FileUploader: FC<PropsInterface> = ({
         const file = acceptedFiles[0];
 
         if (file.size > maxSize) {
-          onError?.(new Error('FileSizeTooLarge'));
+          onError?.(new Error(ErrorsEnum.FileSizeTooLarge));
         } else {
           onFilesUpload(acceptedFiles[0]);
         }


### PR DESCRIPTION
We had a limit set of 50.1MB but no handling of this error, which is now implemented.
Also max model size is clearly mentioned now.