### PR TITLE
Model preview improvements - ability to take snapshots from preview

### DIFF
--- a/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.endpoints.ts
@@ -3,6 +3,7 @@ export const assets3dRepositoryEndpoints = () => {
 
   return {
     base: BASE_URL,
-    upload: `${BASE_URL}/upload`
+    upload: `${BASE_URL}/upload`,
+    patchMeta: `${BASE_URL}/:assetId`
   };
 };

--- a/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.ts
+++ b/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.ts
@@ -7,19 +7,23 @@ import {assets3dRepositoryEndpoints} from './assets3dRepository.api.endpoints';
 import {
   FetchAssets3dRequest,
   FetchAssets3dResponse,
+  PatchAsset3dRequest,
   UploadAsset3dRequest,
-  UploadAsset3dResponse
+  UploadAsset3dResponse,
+  Asset3dInterface
 } from './assets3dRepository.api.types';
 
 export const upload3DAsset: RequestInterface<UploadAsset3dRequest, UploadAsset3dResponse> = (
   options
 ) => {
-  const {asset, name, headers, worldId, ...restOptions} = options;
+  const {asset, name, headers, worldId, preview_hash, ...restOptions} = options;
 
   const formData: FormData = new FormData();
   formData.append('asset', asset);
   formData.append('name', name);
-
+  if (preview_hash) {
+    formData.append('preview_hash', preview_hash);
+  }
   const requestOptions = {
     headers: {
       'Content-Type': 'multipart/form-data',
@@ -45,4 +49,14 @@ export const fetchAssets3d: RequestInterface<FetchAssets3dRequest, FetchAssets3d
   const url = generatePath(assets3dRepositoryEndpoints().base, {worldId});
 
   return request.get(url, restOptions);
+};
+
+export const patchAssets3dMetadata: RequestInterface<PatchAsset3dRequest, Asset3dInterface> = (
+  options
+) => {
+  const {worldId, assetId, name, preview_hash, ...restOptions} = options;
+
+  const url = generatePath(assets3dRepositoryEndpoints().patchMeta, {worldId, assetId});
+
+  return request.patch(url, {meta: {name, preview_hash}}, restOptions);
 };

--- a/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.types.ts
+++ b/packages/app/src/api/repositories/assets3dRepository/assets3dRepository.api.types.ts
@@ -8,11 +8,18 @@ interface Asset3dRequest {
 export interface UploadAsset3dRequest extends Asset3dRequest {
   asset: File;
   name: string;
+  preview_hash?: string;
 }
 
 export interface UploadAsset3dResponse {
   id: string;
   meta: MetadataInterface;
+}
+
+export interface PatchAsset3dRequest extends Asset3dRequest {
+  assetId: string;
+  name?: string;
+  preview_hash?: string;
 }
 
 export interface Asset3dMetadataInterface {

--- a/packages/app/src/core/models/Asset3d/Asset3d.ts
+++ b/packages/app/src/core/models/Asset3d/Asset3d.ts
@@ -1,17 +1,26 @@
 import {Instance, types} from 'mobx-state-tree';
+import {ImageSizeEnum} from '@momentum-xyz/ui-kit';
 
 import {appVariables} from 'api/constants';
 
 const Asset3d = types
   .model('Asset3d', {
     id: types.identifier,
+    category: types.maybeNull(types.string),
     name: types.string,
+    // TODO remove
     image: types.string,
+    preview_hash: types.maybeNull(types.string),
     isUserAttribute: types.optional(types.boolean, false)
   })
   .views((self) => ({
     get thumbnailAssetDownloadUrl(): string {
       return `${appVariables.RENDER_SERVICE_URL}/asset/${self.id.replace(/-/g, '')}`;
+    },
+    get previewUrl(): string {
+      return self.preview_hash
+        ? `${appVariables.RENDER_SERVICE_URL}/texture/${ImageSizeEnum.S3}/${self.preview_hash}`
+        : `https://dev.odyssey.ninja/api/v3/render/texture/${ImageSizeEnum.S4}/03ce359d18bfc0fe977bd66ab471d222`;
     }
   }));
 

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/SpawnAssetPage.routes.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/SpawnAssetPage.routes.tsx
@@ -21,7 +21,7 @@ export const SPAWN_ASSET_ROUTES: RouteConfigInterface[] = [
   },
   {
     path: ROUTES.odyssey.creator.spawnAsset.customAssets,
-    main: () => <AssetsPage assetCategory={Asset3dCategoryEnum.CUSTOM} />,
+    main: () => <AssetsPage assetCategory={Asset3dCategoryEnum.CUSTOM} showPreview />,
     exact: true
   },
   {

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
@@ -10,10 +10,11 @@ import * as styled from './AssetsGrid.styled';
 
 interface PropsInterface {
   assets: Asset3dInterface[];
+  showPreview?: boolean;
   onSelected: (asset: Asset3dInterface) => void;
 }
 
-const AssetGrid: FC<PropsInterface> = ({assets, onSelected}) => {
+const AssetGrid: FC<PropsInterface> = ({assets, showPreview, onSelected}) => {
   const [hoveringAsset, setHoveringAsset] = useState<Asset3dInterface | null>(null);
 
   const {t} = useTranslation();
@@ -40,7 +41,7 @@ const AssetGrid: FC<PropsInterface> = ({assets, onSelected}) => {
             setHoveringAsset(null);
           }}
         >
-          {hoveringAsset !== asset ? (
+          {hoveringAsset !== asset || !showPreview ? (
             <styled.GridItemImage src={asset.image} />
           ) : (
             <styled.GridItemPreview>

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
@@ -33,11 +33,9 @@ const AssetGrid: FC<PropsInterface> = ({assets, showPreview, onSelected}) => {
         <styled.GridItem
           key={asset.id}
           onPointerOver={() => {
-            console.log('enter');
             setHoveringAsset(asset);
           }}
           onPointerLeave={() => {
-            console.log('leave');
             setHoveringAsset(null);
           }}
         >

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
@@ -40,10 +40,11 @@ const AssetGrid: FC<PropsInterface> = ({assets, showPreview, onSelected}) => {
           }}
         >
           {hoveringAsset !== asset || !showPreview ? (
-            <styled.GridItemImage src={asset.image} />
+            <styled.GridItemImage src={asset.previewUrl} />
           ) : (
             <styled.GridItemPreview>
               <Model3dPreview
+                previewUrl={asset.previewUrl}
                 delayLoadingMsec={500}
                 filename={hoveringAsset.thumbnailAssetDownloadUrl}
               />

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/AssetsPage/AssetsPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/AssetsPage/AssetsPage.tsx
@@ -12,10 +12,15 @@ import * as styled from './AssetsPage.styled';
 
 interface PropsInterface {
   assetCategory: Asset3dCategoryEnum;
+  showPreview?: boolean;
   setFunctionalityAfterCreation?: boolean;
 }
 
-const AssetsPage: FC<PropsInterface> = ({assetCategory, setFunctionalityAfterCreation = false}) => {
+const AssetsPage: FC<PropsInterface> = ({
+  assetCategory,
+  setFunctionalityAfterCreation = false,
+  showPreview
+}) => {
   const {odysseyCreatorStore} = useStore();
   const {spawnAssetStore} = odysseyCreatorStore;
 
@@ -47,7 +52,11 @@ const AssetsPage: FC<PropsInterface> = ({assetCategory, setFunctionalityAfterCre
 
   return (
     <styled.Contaier>
-      <AssetsGrid assets={spawnAssetStore.filteredAsset3dList} onSelected={handleSelected} />
+      <AssetsGrid
+        assets={spawnAssetStore.filteredAsset3dList}
+        showPreview={showPreview}
+        onSelected={handleSelected}
+      />
     </styled.Contaier>
   );
 };

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/SelectedPage/SelectedPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/SelectedPage/SelectedPage.tsx
@@ -86,8 +86,6 @@ export const SelectedPage: FC = () => {
           filename={asset.thumbnailAssetDownloadUrl}
           previewUrl={asset.previewUrl}
           onSnapshot={asset.category === 'custom' ? handleSnapshot : undefined}
-          // TODO take snapshow, ask confirmation to replace original
-          // check asset type "custom" to determine whether to do it
         />
       </styled.PreviewContainer>
       <styled.NameLabel text={asset.name} size="m" />

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/SelectedPage/SelectedPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/SelectedPage/SelectedPage.tsx
@@ -66,7 +66,11 @@ export const SelectedPage: FC = () => {
   return (
     <styled.Container>
       <styled.PreviewContainer>
-        <Model3dPreview filename={asset.thumbnailAssetDownloadUrl} />
+        <Model3dPreview
+          filename={asset.thumbnailAssetDownloadUrl}
+          // TODO take snapshow, ask confirmation to replace original
+          // check asset type "custom" to determine whether to do it
+        />
       </styled.PreviewContainer>
       <styled.NameLabel text={asset.name} size="m" />
       <styled.CheckBoxLabel>

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/SelectedPage/SelectedPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/SelectedPage/SelectedPage.tsx
@@ -1,7 +1,7 @@
 import {observer} from 'mobx-react-lite';
 import {FC, useCallback, useEffect} from 'react';
 import {generatePath, useHistory, useParams} from 'react-router-dom';
-import {Button, Text} from '@momentum-xyz/ui-kit';
+import {Button, FileUploader, Text} from '@momentum-xyz/ui-kit';
 import {useTranslation} from 'react-i18next';
 import {Model3dPreview} from '@momentum-xyz/map3d';
 
@@ -43,6 +43,22 @@ export const SelectedPage: FC = () => {
     });
   }, [history, spawnAssetStore, worldId]);
 
+  const handleDevUpload = (file: File | undefined) => {
+    console.log({file, asset});
+    if (asset && file) {
+      spawnAssetStore
+        .devUploadImage(file)
+        .then((imageHash) => {
+          alert(
+            `UPDATE asset_3d SET meta = jsonb_set(meta, '{preview_hash}', '"${imageHash}"', TRUE) WHERE asset_3d_id = '${asset.id}';`
+          );
+        })
+        .catch((err) => {
+          alert(err);
+        });
+    }
+  };
+
   if (!asset) {
     return null;
   }
@@ -78,6 +94,17 @@ export const SelectedPage: FC = () => {
           history.goBack();
         }}
       />
+      {process.env.NODE_ENV === 'development' && (
+        <FileUploader
+          label="DEV - Upload PREVIEW Image"
+          dragActiveLabel="Drop the files here..."
+          fileType="image"
+          buttonSize="small"
+          onFilesUpload={handleDevUpload}
+          onError={(error) => console.error(error)}
+          enableDragAndDrop={false}
+        />
+      )}
     </styled.Container>
   );
 };

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/pages/UploadCustomAssetPage/UploadCustomAssetPage.tsx
@@ -81,6 +81,8 @@ const UploadCustomAssetPage: FC = () => {
               filename={URL.createObjectURL(asset)}
               // TODO it should not be necessary, but currently cannot replace already loaded model
               key={URL.createObjectURL(asset)}
+              // TODO handle snapshot creation and set it to state
+              // then upload it to media manager and attach its hash to asset upload
             />
           </styled.PreviewContainer>
           <styled.NameInput

--- a/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
+++ b/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
@@ -81,6 +81,14 @@ const SpawnAssetStore = types
       console.log('uploadAsset response', response);
       return !!response;
     }),
+    devUploadImage: flow(function* (file: File) {
+      const data = {file: file};
+      const userResponse = yield self.uploadAssetRequest.send(
+        api.mediaRepository.uploadImage,
+        data
+      );
+      return userResponse?.hash;
+    }),
     fetchAssets3d: flow(function* (category: Asset3dCategoryEnum) {
       self.assets3d = cast([]);
 

--- a/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
+++ b/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
@@ -94,15 +94,17 @@ const SpawnAssetStore = types
 
       if (response) {
         const assets =
-          response.map(({id, meta: {name, preview_hash}}) => ({
-            id,
-            name,
-            image:
-              // FIXME - temp until proper preview images are available
-              preview_hash
-                ? `${appVariables.RENDER_SERVICE_URL}/texture/${ImageSizeEnum.S3}/${preview_hash}`
-                : `https://dev.odyssey.ninja/api/v3/render/texture/${ImageSizeEnum.S4}/03ce359d18bfc0fe977bd66ab471d222`
-          })) || [];
+          response
+            .map(({id, meta: {name, preview_hash}}) => ({
+              id,
+              name,
+              image:
+                // FIXME - temp until proper preview images are available
+                preview_hash
+                  ? `${appVariables.RENDER_SERVICE_URL}/texture/${ImageSizeEnum.S3}/${preview_hash}`
+                  : `https://dev.odyssey.ninja/api/v3/render/texture/${ImageSizeEnum.S4}/03ce359d18bfc0fe977bd66ab471d222`
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name)) || [];
 
         self.assets3d = cast(assets);
       }

--- a/packages/map3d/src/components/Model3dPreview/Model3dPreview.styled.ts
+++ b/packages/map3d/src/components/Model3dPreview/Model3dPreview.styled.ts
@@ -28,3 +28,15 @@ export const Container = styled.div`
   width: 100%;
   height: 100%;
 `;
+
+export const SnapshotButtonHolder = styled.div`
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  z-index: 1;
+  cursor: pointer;
+  opacity: 0.7;
+  &:hover {
+    opacity: 1;
+  }
+`;

--- a/packages/map3d/src/components/Model3dPreview/Model3dPreview.styled.ts
+++ b/packages/map3d/src/components/Model3dPreview/Model3dPreview.styled.ts
@@ -1,13 +1,20 @@
 import styled from 'styled-components';
 
-export const Canvas = styled.canvas`
+export const Canvas = styled.canvas<{previewUrl?: string}>`
   pointer-events: all;
   width: 100%;
   height: 100%;
   border-radius: 4px;
 
   &.background {
-    background: linear-gradient(to bottom, #b5bdc8 0%, #828c95 36%, #28343b 100%);
+    background: ${(props) =>
+      !props.previewUrl
+        ? 'linear-gradient(to bottom, #b5bdc8 0%, #828c95 36%, #28343b 100%)'
+        : 'none'};
+    background-image: ${(props) => (props.previewUrl ? `url(${props.previewUrl})` : 'none')};
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
   }
 `;
 

--- a/packages/map3d/src/components/Model3dPreview/Model3dPreview.tsx
+++ b/packages/map3d/src/components/Model3dPreview/Model3dPreview.tsx
@@ -10,7 +10,7 @@ import {
 } from 'three';
 import {OrbitControls} from 'three/examples/jsm/controls/OrbitControls';
 import {GLTF, GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js';
-import {IconSvg, ProgressBar} from '@momentum-xyz/ui-kit';
+import {ProgressBar} from '@momentum-xyz/ui-kit';
 import cn from 'classnames';
 
 import * as styled from './Model3dPreview.styled';
@@ -90,6 +90,7 @@ export interface PropsInterface {
   filename: string;
   delayLoadingMsec?: number;
   background?: boolean;
+  previewUrl?: string;
   onSnapshot?: (dataUrl: string, initial: boolean) => void;
 }
 
@@ -97,12 +98,14 @@ export const Model3dPreview: FC<PropsInterface> = ({
   filename,
   background = true,
   delayLoadingMsec,
+  previewUrl,
   onSnapshot
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const [progress, setProgress] = useState<number | null>(null);
   const [scene, setScene] = useState<Scene>();
+  const [isModelLoaded, setIsModelLoaded] = useState(false);
   const renderRef = useRef<() => void>();
   const disposeRef = useRef<() => void>();
   const autoPosRef = useRef<(gltf: GLTF) => void>();
@@ -182,6 +185,7 @@ export const Model3dPreview: FC<PropsInterface> = ({
           }
         }, 100);
 
+        setIsModelLoaded(true);
         setProgress(null);
       },
       (progress) => {
@@ -222,16 +226,17 @@ export const Model3dPreview: FC<PropsInterface> = ({
       )}
       <styled.Canvas
         className={cn({background})}
+        previewUrl={!isModelLoaded ? previewUrl : undefined}
         style={{width: '100%', height: '100%'}}
         ref={canvasRef}
       />
-      {onSnapshot && (
-        <styled.SnapshotButtonHolder>
+      {/* TEMP disable it - we also need to remember orientation for the snapshot so it wouldn't be ugly moving from preview to model */}
+      {/* {onSnapshot && (
+        <styled.SnapshotButtonHolder title="Take snapshot">
           <IconSvg
             isWhite
             size="large"
             name="fullscreen"
-            // title="Take snapshot"
             onClick={() => {
               // also possible to use toBlob
               const snapshot = canvasRef.current?.toDataURL();
@@ -241,7 +246,7 @@ export const Model3dPreview: FC<PropsInterface> = ({
             }}
           />
         </styled.SnapshotButtonHolder>
-      )}
+      )} */}
     </styled.Container>
   );
 };

--- a/packages/map3d/src/components/Model3dPreview/Model3dPreview.tsx
+++ b/packages/map3d/src/components/Model3dPreview/Model3dPreview.tsx
@@ -154,7 +154,9 @@ export const Model3dPreview: FC<PropsInterface> = ({
 
     console.log('Loading 3D model', filename);
 
-    setProgress(0);
+    // TODO uncomment this when all models can be loaded - for now the unity ones fail to load
+    // and it leads to annoying blinking
+    // setProgress(0);
     loader.load(
       filename,
       (gltf) => {


### PR DESCRIPTION
The main change is taking model preview snapshot right after it's loaded by three.js.

This snapshot is uploaded to media managed and the used during 3d asset upload.

It's also taken when custom model is selected and opened from spawn model popup - it's a bit hacky but if no preview_hash is found in the asset metadata, it's silently patched with the snapshot.

The preview_hash is used in Asset Grid and when model is selected - if hovering over asset grid item, the model is loaded and shown instead of preview - in most cases it's pretty smooth and hardly noticeable.

Right now it's the snapshot of the model taken 100msec after load and render. It's possible to take snapshot later, but we don't currently keep the initial position of the model loaded and in this case it blinks - can be improved in future.

Also assets are sorted by name and few minor improvements are made.