### PR TITLE
fix(asset-grid): long asset names break the layout

### DIFF
--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.styled.ts
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.styled.ts
@@ -14,6 +14,7 @@ export const GridItem = styled.div`
   padding: 10px;
   gap: 15px;
   align-items: center;
+  min-width: 0;
 `;
 
 export const GridItemImage = styled.img`

--- a/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SpawnAssetPage/components/AssetsGrid/AssetsGrid.tsx
@@ -50,7 +50,7 @@ const AssetGrid: FC<PropsInterface> = ({assets, showPreview, onSelected}) => {
               />
             </styled.GridItemPreview>
           )}
-          <Text text={asset.name} size="m" />
+          <Text text={asset.name} size="m" breakLongWord />
           <Button
             label={t('actions.select')}
             size="medium"


### PR DESCRIPTION
Setting min-width 0 to items show prevent them from overexpanding.

https://stackoverflow.com/a/43312314/279308