### PR TITLE
feature: teleport with url

### DIFF
--- a/packages/app/src/api/repositories/web3Repository/web3Repository.api.types.ts
+++ b/packages/app/src/api/repositories/web3Repository/web3Repository.api.types.ts
@@ -31,6 +31,6 @@ export interface ResolveNodeRequest {
 }
 
 export interface ResolveNodeResponse {
-  domain: string;
+  url: string;
   node_id: string;
 }

--- a/packages/app/src/scenes/unity/stores/UnityInstanceStore/UnityInstanceStore.ts
+++ b/packages/app/src/scenes/unity/stores/UnityInstanceStore/UnityInstanceStore.ts
@@ -61,8 +61,8 @@ const UnityInstanceStore = types
     setTargetWorldId(id?: string): void {
       UnityService.setTargetWorldId(id);
     },
-    triggerTeleport(domain?: string, worldId?: string): void {
-      UnityService.triggerTeleport(domain, worldId);
+    triggerTeleport(url?: string, worldId?: string): void {
+      UnityService.triggerTeleport(url, worldId);
     },
     getCurrentWorld(): string | null {
       return UnityService.getCurrentWorld?.() || null;
@@ -200,7 +200,7 @@ const UnityInstanceStore = types
           this.setAddressablesURL(appVariables.UNITY_CLIENT_ADDRESSABLES_URL);
         }
         this.setAuthToken(token);
-        this.triggerTeleport(response.domain, worldId);
+        this.triggerTeleport(response.url, worldId);
         this.setInitialVolume();
       }
     },

--- a/packages/app/src/shared/services/unity/UnityService.tsx
+++ b/packages/app/src/shared/services/unity/UnityService.tsx
@@ -139,10 +139,8 @@ export class UnityService {
     this.unityApi?.setTargetWorldId(id);
   }
 
-  triggerTeleport(domain?: string, worldId?: string) {
-    console.log(domain);
-    console.log(worldId);
-    this.unityApi?.triggerTeleport(domain, worldId);
+  triggerTeleport(url?: string, worldId?: string) {
+    this.unityApi?.triggerTeleport(url, worldId);
   }
 
   pause() {


### PR DESCRIPTION
Instead of domain, allows running backend on different ports (for development).
Backend endpoint was changed to return this new url field.
Unity was changed to accept this type into its teleport function.