### PR TITLE
fix(creator-skyboxes): double calling of saveItem when selecting existing skybox

### DIFF
--- a/packages/app/src/scenes/odysseyCreator/pages/SkyboxSelectorWithPreviewPage/SkyboxSelectorWithPreviewPage.tsx
+++ b/packages/app/src/scenes/odysseyCreator/pages/SkyboxSelectorWithPreviewPage/SkyboxSelectorWithPreviewPage.tsx
@@ -66,15 +66,7 @@ const SkyboxSelectorWithPreviewPage: FC = () => {
                 {currPageSkyboxes.map((item, idx) => {
                   const active = item === currentItem;
                   return (
-                    <styled.Item
-                      className={cn({active})}
-                      key={item.id + `-${idx}`}
-                      onClick={() => {
-                        saveItem(item.id, worldId!).catch((err) => {
-                          toast.error(err.message);
-                        });
-                      }}
-                    >
+                    <styled.Item className={cn({active})} key={item.id + `-${idx}`}>
                       {item.isUserAttribute && item.id !== currentItemId && (
                         <styled.DeleteButtonHolder>
                           <SvgButton


### PR DESCRIPTION
There's saveItem in Button onClick and its parent Item - the parent's one is not needed.