### PR TITLE
API change "space" -> "object" in routes and arguments

### DIFF
--- a/packages/app/src/api/repositories/agoraRepository/agoraRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/agoraRepository/agoraRepository.api.endpoints.ts
@@ -1,5 +1,5 @@
 export const agoraRepositoryApiEndpoints = () => {
-  const BASE_URL = '/spaces';
+  const BASE_URL = '/objects';
 
   return {
     token: `${BASE_URL}/:spaceId/agora/token`

--- a/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttribute.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttribute.api.endpoints.ts
@@ -1,5 +1,5 @@
 export const spaceAttributesRepositoryEndpoints = () => {
-  const BASE_URL = '/spaces/:spaceId/attributes';
+  const BASE_URL = '/objects/:spaceId/attributes';
 
   return {
     attributes: `${BASE_URL}`,

--- a/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.endpoints.ts
@@ -1,5 +1,5 @@
 export const spaceInfoRepository = () => {
-  const BASE_URL = '/spaces';
+  const BASE_URL = '/objects';
 
   return {
     spaceInfo: `${BASE_URL}/:spaceId`

--- a/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.ts
+++ b/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.ts
@@ -24,9 +24,9 @@ export const getSpaceInfo: RequestInterface<GetSpaceInfoRequest, GetSpaceInfoRes
 export const patchSpaceInfo: RequestInterface<PatchSpaceInfoRequest, PatchSpaceInfoResponse> = (
   options
 ) => {
-  const {spaceId, asset_2d_id, asset_3d_id, space_type_id, ...restOptions} = options;
+  const {spaceId, asset_2d_id, asset_3d_id, object_type_id, ...restOptions} = options;
 
   const url = generatePath(spaceInfoRepository().spaceInfo, {spaceId});
 
-  return request.patch(url, {asset_2d_id, asset_3d_id, space_type_id}, restOptions);
+  return request.patch(url, {asset_2d_id, asset_3d_id, object_type_id}, restOptions);
 };

--- a/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.types.ts
+++ b/packages/app/src/api/repositories/spaceInfoRepository/spaceInfoRepository.api.types.ts
@@ -11,7 +11,7 @@ export interface GetSpaceInfoRequest {
 export interface GetSpaceInfoResponse {
   owner_id: string;
   parent_id: string;
-  space_type_id: string;
+  object_type_id: string;
   asset_2d_id: string;
   asset_3d_id: string;
   position: PositionInterface;
@@ -19,7 +19,7 @@ export interface GetSpaceInfoResponse {
 
 export interface PatchSpaceInfoRequest {
   spaceId: string;
-  space_type_id?: string;
+  object_type_id?: string;
   asset_2d_id?: string;
   asset_3d_id?: string;
 }

--- a/packages/app/src/api/repositories/spaceOptionRepository/spaceOptionRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceOptionRepository/spaceOptionRepository.api.endpoints.ts
@@ -1,5 +1,5 @@
 export const spaceOptionRepositoryEndpoints = () => {
-  const BASE_URL = '/spaces/:spaceId';
+  const BASE_URL = '/objects/:spaceId';
 
   return {
     options: `${BASE_URL}/options`,

--- a/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.endpoints.ts
@@ -1,5 +1,5 @@
 export const spaceRepositoryEndpoints = () => {
-  const BASE_URL = '/spaces';
+  const BASE_URL = '/objects';
 
   return {
     base: `${BASE_URL}`,

--- a/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.ts
+++ b/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.ts
@@ -47,14 +47,21 @@ export const fetchDocksCount: RequestInterface<GetDocksCountRequest, GetDocksCou
 };
 
 export const postSpace: RequestInterface<PostSpaceRequest, PostSpaceResponse> = (options) => {
-  const {space_name, parent_id, space_type_id, asset_2d_id, asset_3d_id, minimap, ...restOptions} =
-    options;
+  const {
+    object_name,
+    parent_id,
+    object_type_id,
+    asset_2d_id,
+    asset_3d_id,
+    minimap,
+    ...restOptions
+  } = options;
 
   return request.post(
     spaceRepositoryEndpoints().base,
     {
-      space_name,
-      space_type_id,
+      object_name,
+      object_type_id,
       parent_id,
       asset_2d_id,
       asset_3d_id,

--- a/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.types.ts
+++ b/packages/app/src/api/repositories/spaceRepository/spaceRepository.api.types.ts
@@ -10,8 +10,8 @@ export interface FetchSpaceResponse extends SpaceInterface {}
 
 export interface PostSpaceRequest {
   parent_id: string;
-  space_name: string;
-  space_type_id: string;
+  object_name: string;
+  object_type_id: string;
 
   asset_2d_id?: string;
   asset_3d_id?: string;

--- a/packages/app/src/api/repositories/spaceUserAttributeRepository/spaceUserAttributeRepository.api.endpoints.ts
+++ b/packages/app/src/api/repositories/spaceUserAttributeRepository/spaceUserAttributeRepository.api.endpoints.ts
@@ -1,5 +1,5 @@
 export const spaceUserAttributeRepositoryEndpoints = () => {
-  const BASE_URL = '/spaces';
+  const BASE_URL = '/objects';
 
   return {
     attribute: `${BASE_URL}/:spaceId/:userId/attributes`,

--- a/packages/app/src/scenes/odysseyCreator/stores/SkyboxSelectorStore/SkyboxSelectorStore.ts
+++ b/packages/app/src/scenes/odysseyCreator/stores/SkyboxSelectorStore/SkyboxSelectorStore.ts
@@ -89,20 +89,20 @@ const SkyboxSelectorStore = types
       yield self.fetchDefaultSkyboxes();
       yield self.fetchUserSkyboxes(worldId, userId);
 
-      const {spaces} = yield self.worldSettingsRequest.send(
+      const {objects} = yield self.worldSettingsRequest.send(
         api.spaceAttributeRepository.getSpaceAttribute,
         {
           spaceId: worldId,
           plugin_id: PluginIdEnum.CORE,
           attribute_name: AttributeNameEnum.WORLD_SETTINGS,
-          sub_attribute_key: 'spaces'
+          sub_attribute_key: 'objects'
         }
       );
 
       const activeSkyboxData = yield self.createSkyboxRequest.send(
         api.spaceAttributeRepository.getSpaceAttribute,
         {
-          spaceId: spaces.skybox,
+          spaceId: objects.skybox,
           plugin_id: PluginIdEnum.CORE,
           attribute_name: AttributeNameEnum.ACTIVE_SKYBOX
         }
@@ -145,23 +145,23 @@ const SkyboxSelectorStore = types
     saveItem: flow(function* (id: string, worldId: string) {
       self.currentItemId = id;
 
-      const {spaces} = yield self.worldSettingsRequest.send(
+      const {objects} = yield self.worldSettingsRequest.send(
         api.spaceAttributeRepository.getSpaceAttribute,
         {
           spaceId: worldId,
           plugin_id: PluginIdEnum.CORE,
           attribute_name: AttributeNameEnum.WORLD_SETTINGS,
-          sub_attribute_key: 'spaces'
+          sub_attribute_key: 'objects'
         }
       );
 
       yield self.worldSettingsRequest.send(api.spaceInfoRepository.patchSpaceInfo, {
-        spaceId: spaces.skybox,
+        spaceId: objects.skybox,
         asset_3d_id: UNITY_SKYBOX_ASSET_ID
       });
 
       yield self.createSkyboxRequest.send(api.spaceAttributeRepository.setSpaceAttribute, {
-        spaceId: spaces.skybox,
+        spaceId: objects.skybox,
         plugin_id: PluginIdEnum.CORE,
         attribute_name: AttributeNameEnum.ACTIVE_SKYBOX,
         value: {render_hash: id}

--- a/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
+++ b/packages/app/src/scenes/odysseyCreator/stores/SpawnAssetStore/SpawnAssetStore.ts
@@ -147,9 +147,9 @@ const SpawnAssetStore = types
         api.spaceRepository.postSpace,
         {
           parent_id: worldId,
-          space_name: self.navigationObjectName,
+          object_name: self.navigationObjectName,
           // TODO: What is it for? Discussion !!!
-          space_type_id: '4ed3a5bb-53f8-4511-941b-07902982c31c',
+          object_type_id: '4ed3a5bb-53f8-4511-941b-07902982c31c',
           asset_3d_id: self.selectedAssset?.id,
           minimap: self.isVisibleInNavigation
         }


### PR DESCRIPTION
It's the first part of the changes related to API refactoring.

Internally we might also change `spaceId` to `objectId` particularly in the routes.