### PR TITLE
World3D: autohide gizmo, debounce UserMove message, send ObjectTransform to posbus

### DIFF
--- a/packages/app/src/scenes/odysseyCreator/OdysseyCreator.tsx
+++ b/packages/app/src/scenes/odysseyCreator/OdysseyCreator.tsx
@@ -19,7 +19,7 @@ const OdysseyCreator: FC = () => {
     return () => {
       world3dStore?.disableCreatorMode();
     };
-  }, []);
+  }, [world3dStore]);
 
   return (
     <>

--- a/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
+++ b/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
@@ -45,10 +45,9 @@ const WorldPage: FC = () => {
 
   useEffect(() => {
     return () => {
-      universeStore.leaveWorld();
       widgetManagerStore.closeAll();
     };
-  }, [universeStore, widgetManagerStore]);
+  }, [widgetManagerStore]);
 
   // useEffect(() => {
   //   instance3DStore.init();
@@ -87,6 +86,9 @@ const WorldPage: FC = () => {
 
       universeStore.enterWorld(worldId);
     }
+    return () => {
+      universeStore.leaveWorld();
+    };
   }, [worldId, universeStore]);
 
   const handleObjectClick = (objectId: string, clickPositin: ClickPositionInterface) => {
@@ -96,20 +98,9 @@ const WorldPage: FC = () => {
       // TODO take coords from event
       // instance3DStore.setLastClickPosition
 
-      if (world3dStore?.selectedObjectId) {
-        if (world3dStore?.selectedObjectId === objectId) {
-          return;
-        }
-
-        Event3dEmitter.emit('ObjectEditModeChanged', world3dStore.selectedObjectId, false);
-      }
-
-      // TODO try to lock object and wait for lock to be acquired
-      Event3dEmitter.emit('ObjectEditModeChanged', objectId, true);
-
       navigate(generatePath(ROUTES.odyssey.creator.base, {worldId: universeStore.worldId}));
 
-      world3dStore?.onObjectClick(objectId);
+      world3dStore?.handleClick(objectId);
     } else {
       console.log('BabylonPage: handle object click, NOT creator mode', objectId);
       // if (label === 'portal_odyssey') {
@@ -123,6 +114,11 @@ const WorldPage: FC = () => {
         })
       });
     }
+  };
+
+  const handleClickOutside = () => {
+    console.log('BabylonPage: handleClickOutside');
+    world3dStore?.closeAndResetObjectMenu();
   };
 
   const handleUserClick = (id: string, clickPosition: ClickPositionInterface) => {
@@ -222,7 +218,7 @@ const WorldPage: FC = () => {
   //   return <></>;
   // }
 
-  console.log('WorldPage render');
+  console.log('WorldPage render', {worldId, world3dStore});
 
   return (
     <styled.Inner
@@ -239,8 +235,8 @@ const WorldPage: FC = () => {
           console.log('onObjectTransform', objectId, transform)
         }
         onUserClick={handleUserClick}
+        onClickOutside={handleClickOutside}
       />
-      {/* <Unity unityContext={instance3DStore.unityContext} style={UnityContextCSS} /> */}
     </styled.Inner>
   );
 };

--- a/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
+++ b/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
@@ -8,6 +8,7 @@ import {BabylonScene} from '@momentum-xyz/odyssey3d';
 import {
   ClickPositionInterface,
   Event3dEmitter,
+  ObjectTransformInterface,
   TransformNoScaleInterface,
   useI18n
 } from '@momentum-xyz/core';
@@ -136,6 +137,17 @@ const WorldPage: FC = () => {
     {maxWait: 250}
   );
 
+  const handleObjectTransform = useDebouncedCallback(
+    (objectId: string, transform: ObjectTransformInterface) => {
+      console.log('BabylonPage: onObjectTransform', objectId, transform);
+
+      PosBusService.sendObjectTransform(objectId, transform);
+    },
+    250,
+    [],
+    {maxWait: 250}
+  );
+
   // usePosBusEvent('fly-to-me', (spaceId, userId, userName) => {
   //   if (sessionStore.userId === userId) {
   //     toast.info(
@@ -238,9 +250,7 @@ const WorldPage: FC = () => {
         events={Event3dEmitter}
         onMove={handleUserMove}
         onObjectClick={handleObjectClick}
-        onObjectTransform={(objectId, transform) =>
-          console.log('onObjectTransform', objectId, transform)
-        }
+        onObjectTransform={handleObjectTransform}
         onUserClick={handleUserClick}
         onClickOutside={handleClickOutside}
       />

--- a/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
+++ b/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
@@ -91,7 +91,7 @@ const WorldPage: FC = () => {
     };
   }, [worldId, universeStore]);
 
-  const handleObjectClick = (objectId: string, clickPositin: ClickPositionInterface) => {
+  const handleObjectClick = (objectId: string, clickPos: ClickPositionInterface) => {
     if (universeStore.isCreatorMode) {
       console.log('BabylonPage: handle object click in creator mode', objectId);
 
@@ -100,7 +100,7 @@ const WorldPage: FC = () => {
 
       navigate(generatePath(ROUTES.odyssey.creator.base, {worldId: universeStore.worldId}));
 
-      world3dStore?.handleClick(objectId);
+      world3dStore?.handleClick(objectId, clickPos);
     } else {
       console.log('BabylonPage: handle object click, NOT creator mode', objectId);
       // if (label === 'portal_odyssey') {
@@ -223,9 +223,11 @@ const WorldPage: FC = () => {
   return (
     <styled.Inner
       data-testid="UnityPage-test"
-      onClick={(event) => {
-        world3dStore?.setLastClickPosition(event.clientX, event.clientY);
-      }}
+      // it gets called after object click thus requiring to put some delays to its handler
+      // onObjectClick now provides this info, so commenting this out
+      // onClick={(event) => {
+      //   world3dStore?.setLastClickPosition(event.clientX, event.clientY);
+      // }}
     >
       <BabylonScene
         events={Event3dEmitter}

--- a/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
+++ b/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
@@ -3,8 +3,7 @@ import {observer} from 'mobx-react-lite';
 // import {useTheme} from 'styled-components';
 import {generatePath, matchPath, useNavigate, useLocation} from 'react-router-dom';
 import {toast} from 'react-toastify';
-// import Unity from 'react-unity-webgl';
-//import {Portal} from '@momentum-xyz/ui-kit';
+import {useDebouncedCallback} from '@momentum-xyz/ui-kit-storybook';
 import {BabylonScene} from '@momentum-xyz/odyssey3d';
 import {
   ClickPositionInterface,
@@ -126,10 +125,16 @@ const WorldPage: FC = () => {
     widgetsStore.odysseyInfoStore.open(id);
   };
 
-  const handleUserMove = (transform: TransformNoScaleInterface) => {
-    console.log('BabylonPage: onMove', transform);
-    PosBusService.sendMyTransform(transform);
-  };
+  const handleUserMove = useDebouncedCallback(
+    (transform: TransformNoScaleInterface) => {
+      console.log('BabylonPage: onMove', transform);
+      world3dStore?.handleUserMove(transform);
+      PosBusService.sendMyTransform(transform); // move this to world3dStore??
+    },
+    250,
+    [],
+    {maxWait: 250}
+  );
 
   // usePosBusEvent('fly-to-me', (spaceId, userId, userName) => {
   //   if (sessionStore.userId === userId) {

--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -7,7 +7,11 @@ import {
   PosbusPort
   // posbus
 } from '@momentum-xyz/posbus-client';
-import {Event3dEmitter, TransformNoScaleInterface} from '@momentum-xyz/core';
+import {
+  Event3dEmitter,
+  ObjectTransformInterface,
+  TransformNoScaleInterface
+} from '@momentum-xyz/core';
 
 // import {VoiceChatActionEnum} from 'api/enums';
 import {PosBusEventEmitter} from 'core/constants';
@@ -196,6 +200,13 @@ class PosBusService {
 
   static sendMyTransform(transform: TransformNoScaleInterface) {
     this.main.port?.postMessage([MsgType.MY_TRANSFORM, transform]);
+  }
+
+  static sendObjectTransform(objectId: string, transform: ObjectTransformInterface) {
+    this.main.port?.postMessage([
+      MsgType.OBJECT_TRANSFORM,
+      {id: objectId, object_transform: transform}
+    ]);
   }
 
   static requestObjectLock(objectId: string, lock: boolean) {

--- a/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
+++ b/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
@@ -87,7 +87,9 @@ const World3dStore = types
       // return rotation;
     },
     handleUserMove(transform: TransformNoScaleInterface): void {
-      self.userCurrentTransform = transform;
+      // FIXME storing it here changes the structure and breaks stuff
+      // maybe deep-copy it or something?
+      // self.userCurrentTransform = cast(transform);
     },
     teleportToUser(userId: string): void {
       // TODO Use Emitter3d

--- a/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
+++ b/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
@@ -1,5 +1,5 @@
 import {cast, types} from 'mobx-state-tree';
-import {RequestModel, Dialog, Event3dEmitter} from '@momentum-xyz/core';
+import {RequestModel, Dialog, Event3dEmitter, ClickPositionInterface} from '@momentum-xyz/core';
 import {UnityControlInterface} from '@momentum-xyz/sdk';
 
 // import {api, ResolveNodeResponse} from 'api';
@@ -10,6 +10,8 @@ import {UnityPositionInterface} from 'core/interfaces';
 const DEFAULT_UNITY_VOLUME = 0.75;
 // const UNITY_VOLUME_STEP = 0.1;
 
+const defaultClickPosition = {x: 0, y: 0};
+
 const World3dStore = types
   .model('World3dStore', {
     // TODO: objectList: array
@@ -17,8 +19,11 @@ const World3dStore = types
     muted: false,
     volume: types.optional(types.number, DEFAULT_UNITY_VOLUME),
     nodeRequest: types.optional(RequestModel, {}),
-    lastClickPosition: types.optional(types.frozen<{x: number; y: number}>(), {x: 0, y: 0}),
-    objectMenuPosition: types.optional(types.frozen<{x: number; y: number}>(), {x: 0, y: 0}),
+    // lastClickPosition: types.optional(types.frozen<{x: number; y: number}>(), {x: 0, y: 0}),
+    objectMenuPosition: types.optional(
+      types.frozen<ClickPositionInterface>(),
+      defaultClickPosition
+    ),
     objectMenu: types.optional(Dialog, {}),
     isCreatorMode: false,
     selectedObjectId: types.maybeNull(types.string),
@@ -173,12 +178,12 @@ const World3dStore = types
     //     this.setInitialVolume();
     //   }
     // },
-    setLastClickPosition(x: number, y: number) {
-      console.log('setLastClickPosition', x, y);
-      self.lastClickPosition = {x, y};
-      // this.closeAndResetObjectMenu();
-    },
-    handleClick(objectId: string) {
+    // setLastClickPosition(x: number, y: number) {
+    //   console.log('setLastClickPosition', x, y);
+    //   self.lastClickPosition = {x, y};
+    //   // this.closeAndResetObjectMenu();
+    // },
+    handleClick(objectId: string, clickPos?: ClickPositionInterface) {
       console.log('World3dStore : handleClick', objectId);
       if (!self.isCreatorMode) {
         return;
@@ -186,7 +191,7 @@ const World3dStore = types
 
       self._deselectObject();
 
-      // self.objectMenuPosition = self.lastClickPosition;
+      self.objectMenuPosition = clickPos || defaultClickPosition;
 
       self._selectObject(objectId);
       self.objectMenu.open();

--- a/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
+++ b/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
@@ -1,5 +1,11 @@
 import {cast, types} from 'mobx-state-tree';
-import {RequestModel, Dialog, Event3dEmitter, ClickPositionInterface} from '@momentum-xyz/core';
+import {
+  RequestModel,
+  Dialog,
+  Event3dEmitter,
+  ClickPositionInterface,
+  TransformNoScaleInterface
+} from '@momentum-xyz/core';
 import {UnityControlInterface} from '@momentum-xyz/sdk';
 
 // import {api, ResolveNodeResponse} from 'api';
@@ -16,6 +22,7 @@ const World3dStore = types
   .model('World3dStore', {
     // TODO: objectList: array
     isInitialized: false,
+    userCurrentTransform: types.maybeNull(types.frozen<TransformNoScaleInterface>()),
     muted: false,
     volume: types.optional(types.number, DEFAULT_UNITY_VOLUME),
     nodeRequest: types.optional(RequestModel, {}),
@@ -78,6 +85,9 @@ const World3dStore = types
       // }
 
       // return rotation;
+    },
+    handleUserMove(transform: TransformNoScaleInterface): void {
+      self.userCurrentTransform = transform;
     },
     teleportToUser(userId: string): void {
       // TODO Use Emitter3d

--- a/packages/odyssey3d/src/Emulator.tsx
+++ b/packages/odyssey3d/src/Emulator.tsx
@@ -76,6 +76,7 @@ const WorldEmulator: FC = () => {
         console.log('onObjectTransform', objectId, transform)
       }
       onUserClick={(e) => console.log('onUserClick', e)}
+      onClickOutside={() => console.log('onClickOutside')}
     />
   );
 };

--- a/packages/odyssey3d/src/babylon/ObjectHelper.ts
+++ b/packages/odyssey3d/src/babylon/ObjectHelper.ts
@@ -48,7 +48,8 @@ export class ObjectHelper {
     scene: Scene,
     engine: Engine,
     view: HTMLCanvasElement,
-    onObjectClick: (objectId: string, clickPosition: ClickPositionInterface) => void
+    onObjectClick: (objectId: string, clickPosition: ClickPositionInterface) => void,
+    onClickOutside: () => void
   ): void {
     this.scene = scene;
     this.firstID = '';
@@ -84,10 +85,10 @@ export class ObjectHelper {
           /*if (!WorldCreatorHelper.isCreatorMode) {
             WorldCreatorHelper.tryLockObject(parent.metadata);
           }*/
+        } else {
+          // WorldCreatorHelper.unlockLastObject();
+          onClickOutside();
         }
-        /*else {
-          WorldCreatorHelper.unlockLastObject();
-        }*/
       }
     };
   }

--- a/packages/odyssey3d/src/core/interfaces/odyssey3d.interface.ts
+++ b/packages/odyssey3d/src/core/interfaces/odyssey3d.interface.ts
@@ -15,6 +15,9 @@ export interface Odyssey3dPropsInterface {
   onObjectClick: (objectId: string, clickPosition: ClickPositionInterface) => void;
   onObjectTransform: (objectId: string, transform: ObjectTransformInterface) => void;
 
+  // Can be used for clearing gizmo, etc
+  onClickOutside: () => void;
+
   // click on any user
   onUserClick: (userId: string, clickPosition: ClickPositionInterface) => void;
 

--- a/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -1,18 +1,17 @@
 import {FC} from 'react';
 import {Scene} from '@babylonjs/core';
 import SceneComponent from 'babylonjs-hook';
+import {useMutableCallback} from '@momentum-xyz/ui-kit';
 
 import {Odyssey3dPropsInterface} from '../../core/interfaces';
 import {PlayerHelper, LightHelper, ObjectHelper, SkyboxHelper} from '../../babylon';
 import {WorldCreatorHelper} from '../../babylon/WorldCreatorHelper';
 
-const BabylonScene: FC<Odyssey3dPropsInterface> = ({
-  events,
-  onObjectClick,
-  onUserClick,
-  onMove,
-  onObjectTransform
-}) => {
+const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, ...callbacks}) => {
+  const onObjectClick = useMutableCallback(callbacks.onObjectClick);
+  // const onUserClick = useMutableCallback(callbacks.onUserClick);
+  const onMove = useMutableCallback(callbacks.onMove);
+  const onObjectTransform = useMutableCallback(callbacks.onObjectTransform);
   /* Will run one time. */
   const onSceneReady = (scene: Scene) => {
     const view = scene.getEngine().getRenderingCanvas();

--- a/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -12,6 +12,8 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, ...callbacks}) => {
   // const onUserClick = useMutableCallback(callbacks.onUserClick);
   const onMove = useMutableCallback(callbacks.onMove);
   const onObjectTransform = useMutableCallback(callbacks.onObjectTransform);
+  const onClickOutside = useMutableCallback(callbacks.onClickOutside);
+
   /* Will run one time. */
   const onSceneReady = (scene: Scene) => {
     const view = scene.getEngine().getRenderingCanvas();
@@ -24,7 +26,8 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, ...callbacks}) => {
         engine,
         //  props.objects,
         view,
-        onObjectClick
+        onObjectClick,
+        onClickOutside
         // onUserClick,
         // onMove,
       );

--- a/packages/ui-kit/src/hooks/index.ts
+++ b/packages/ui-kit/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useSortableData';
 export * from './useResize';
 export * from './useScroll';
 export * from './useCoordinates';
+export * from './useMutableCallback';

--- a/packages/ui-kit/src/hooks/useMutableCallback.tsx
+++ b/packages/ui-kit/src/hooks/useMutableCallback.tsx
@@ -1,0 +1,14 @@
+import {useRef, useCallback} from 'react';
+
+export const useMutableCallback = <T extends (...args: any[]) => any>(
+  callback: T
+): typeof callback => {
+  const ref = useRef<T | undefined>();
+  ref.current = callback;
+
+  const cbWrap = useCallback((...args: any[]) => {
+    return ref.current?.(...args);
+  }, []);
+
+  return cbWrap as T;
+};


### PR DESCRIPTION
Fix also potential issue with mutable callbacks passed to BabylonScene - they are stored in different helper classes but only the instance at the moment of onSceneReady calling. If the callback is changed afterwards, Babylon classes wouldn't know it.

To fix that I added `useMutableCallback` function storing the changing callback instance behind a constant instance - it can be used for storing it in external classes. It's also useful for the cases when we want to prevent some react components re-rendering due to potentially changeable arguments.