### PR TITLE
chore: add wasm to compression test

### DIFF
--- a/packages/app/craco.config.js
+++ b/packages/app/craco.config.js
@@ -10,7 +10,7 @@ module.exports = {
   webpack: {
     plugins: [
       new CompressionPlugin({
-        test: /\.(js|css|svg)$/,
+        test: /\.(m?js|css|svg|wasm)$/,
         algorithm: 'gzip'
       }),
       new ModuleFederationPlugin({


### PR DESCRIPTION
And mjs files, both are used for loading posbus client worker.