### PR TITLE
Detect wallets installed

### DIFF
--- a/packages/app/src/scenes/widgets/pages/LoginWidget/components/organisms/SignIn/SignIn.tsx
+++ b/packages/app/src/scenes/widgets/pages/LoginWidget/components/organisms/SignIn/SignIn.tsx
@@ -17,6 +17,7 @@ const SignIn: FC<PropsInterface> = ({onConnected}) => {
   const {t} = useI18n();
 
   const [selectedWallet, setSelectedWallet] = useState<WalletConfigInterface | null>(null);
+  // TODO check if we need this separate state in future - we currently don't use it
   const [connectWithWallet, setConnectWithWallet] = useState<boolean>(false);
 
   const openWalletInstallationLink = (url: string): void => {
@@ -48,7 +49,7 @@ const SignIn: FC<PropsInterface> = ({onConnected}) => {
                 key={name}
                 onClick={() => {
                   setSelectedWallet(wallet);
-                  setConnectWithWallet(false);
+                  setConnectWithWallet(true);
                 }}
               >
                 <img src={icon} alt={`${name}-icon`} />

--- a/packages/app/src/scenes/widgets/pages/LoginWidget/components/organisms/WalletLogin/WalletLogin.tsx
+++ b/packages/app/src/scenes/widgets/pages/LoginWidget/components/organisms/WalletLogin/WalletLogin.tsx
@@ -23,12 +23,12 @@ const WalletLogin: FC<PropsInterface> = ({
   onError,
   attachSecondaryAccount = false
 }) => {
-  const {name, useWallet} = walletConf;
+  const {name, useWallet, browserExtensionUrl} = walletConf;
   const {sessionStore} = useStore();
 
   const {t} = useI18n();
 
-  const {signChallenge, content, account, accountHex} = useWallet({
+  const {signChallenge, content, account, isInstalled, accountHex} = useWallet({
     appVariables: appVariables as any
   });
   console.log('WalletLogin', {name, signChallenge, content, account, accountHex});
@@ -61,15 +61,26 @@ const WalletLogin: FC<PropsInterface> = ({
 
   return (
     <styled.Container>
-      {/* <styled.TitleText>{t('login.connectWith', {wallet: name})}</styled.TitleText> */}
-      <styled.WalletInnerViewContainer>{innerView}</styled.WalletInnerViewContainer>
-      <Button
-        label={t('login.connectYourWallet')}
-        icon="wallet"
-        disabled={!accountHex}
-        wide
-        onClick={() => onConnectWallet()}
-      />
+      {isInstalled ? (
+        <>
+          {/* <styled.TitleText>{t('login.connectWith', {wallet: name})}</styled.TitleText> */}
+          <styled.WalletInnerViewContainer>{innerView}</styled.WalletInnerViewContainer>
+          <Button
+            label={t('login.connectYourWallet')}
+            icon="wallet"
+            disabled={!accountHex}
+            wide
+            onClick={() => onConnectWallet()}
+          />
+        </>
+      ) : (
+        <Button
+          label={t('login.installBrowserExtension')}
+          icon="logout" // TODO: Add missing 'install' icon to storybook and use it here
+          wide
+          onClick={() => window.open(browserExtensionUrl, '_blank')}
+        />
+      )}
     </styled.Container>
   );
 };

--- a/packages/app/src/wallets/coinbaseWallet/useWallet.tsx
+++ b/packages/app/src/wallets/coinbaseWallet/useWallet.tsx
@@ -8,6 +8,10 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   const {library, account, activate, deactivate, active} = useWeb3React();
   console.log('CoinbaseWallet useWallet', {library, account, activate, active});
 
+  const {ethereum} = window as any;
+  const isInstalled =
+    ethereum?.isCoinbaseWallet || !!ethereum?.providers?.some((p: any) => p.isCoinbaseWallet);
+
   const signChallenge = useCallback(
     async (challenge: string) => {
       console.log('CoinbaseWallet useWallet connect', challenge);
@@ -41,5 +45,5 @@ export const useWallet: UseWalletType = ({appVariables}) => {
     };
   }, [activate, deactivate, appVariables]);
 
-  return {account, accountHex: account, signChallenge};
+  return {account, accountHex: account, isInstalled, signChallenge};
 };

--- a/packages/app/src/wallets/coinbaseWallet/useWallet.tsx
+++ b/packages/app/src/wallets/coinbaseWallet/useWallet.tsx
@@ -22,6 +22,11 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   );
 
   useEffect(() => {
+    if (!isInstalled) {
+      console.log('CoinbaseWallet useWallet not installed');
+      return;
+    }
+
     console.log('CoinbaseWallet useWallet activate', appVariables.WEB3_PUBLIC_RPC_URL_MAINNET);
 
     const connector = new WalletLinkConnector({
@@ -43,7 +48,7 @@ export const useWallet: UseWalletType = ({appVariables}) => {
       console.log('CoinbaseWallet useWallet deactivate');
       deactivate();
     };
-  }, [activate, deactivate, appVariables]);
+  }, [activate, deactivate, appVariables, isInstalled]);
 
   return {account, accountHex: account, isInstalled, signChallenge};
 };

--- a/packages/app/src/wallets/metamask/useWallet.tsx
+++ b/packages/app/src/wallets/metamask/useWallet.tsx
@@ -13,10 +13,8 @@ const {ethereum} = window as any;
 const metamaskProvider = ethereum?.providers?.find((p: any) => p.isMetaMask);
 
 export const useWallet: UseWalletType = () => {
-  // const {library, account, activate, deactivate, active} = useWeb3React();
-  const data = useWeb3React();
-  const {library, account, activate, active} = data;
-  console.log('useWallet', {library, account, activate, active});
+  const {library, account, activate, deactivate, active} = useWeb3React();
+  console.log('MetaMask useWallet', {library, account, activate, active});
 
   const signChallenge = useCallback(
     async (challenge: string) => {
@@ -40,21 +38,25 @@ export const useWallet: UseWalletType = () => {
       }
     }
 
-    // connector.activate()
-    activate(connector)
-      .then((res) => {
-        console.log('MetaMask useWallet activated res', res);
-      })
-      .catch((err) => {
-        console.log('MetaMask useWallet activate err', err);
-      });
+    // another workaround for Coinbase Wallet
+    // when swtiching from Coinbase Wallet to MetaMask there's some internal race condition
+    // that leaves connector deactivated so timeout helps here
+    // https://github.com/Uniswap/web3-react/issues/78
+    setTimeout(() => {
+      activate(connector)
+        .then((res) => {
+          console.log('MetaMask useWallet activated res', res);
+        })
+        .catch((err) => {
+          console.log('MetaMask useWallet activate err', err);
+        });
+    }, 500);
 
     return () => {
       console.log('MetaMask useWallet deactivate');
-      // deactivate();
+      deactivate();
     };
-  }, [activate]);
-  // }, [activate, deactivate]);
+  }, [activate, deactivate]);
 
   return {account, accountHex: account, signChallenge};
 };

--- a/packages/app/src/wallets/metamask/useWallet.tsx
+++ b/packages/app/src/wallets/metamask/useWallet.tsx
@@ -8,13 +8,14 @@ const connector = new InjectedConnector({
   supportedChainIds: [1, 3, 4, 5, 42]
 });
 
-const {ethereum} = window as any;
-// this structure exists when Coinbase Wallet is installed
-const metamaskProvider = ethereum?.providers?.find((p: any) => p.isMetaMask);
-
 export const useWallet: UseWalletType = () => {
   const {library, account, activate, deactivate, active} = useWeb3React();
   console.log('MetaMask useWallet', {library, account, activate, active});
+
+  const {ethereum} = window as any;
+  // this structure exists when both Metamask and Coinbase Wallet are installed
+  const metamaskProvider = ethereum?.providers?.find((p: any) => p.isMetaMask);
+  const isInstalled = !!metamaskProvider || ethereum?.isMetaMask;
 
   const signChallenge = useCallback(
     async (challenge: string) => {
@@ -58,5 +59,5 @@ export const useWallet: UseWalletType = () => {
     };
   }, [activate, deactivate]);
 
-  return {account, accountHex: account, signChallenge};
+  return {account, accountHex: account, isInstalled, signChallenge};
 };

--- a/packages/app/src/wallets/metamask/useWallet.tsx
+++ b/packages/app/src/wallets/metamask/useWallet.tsx
@@ -27,8 +27,13 @@ export const useWallet: UseWalletType = () => {
   );
 
   useEffect(() => {
-    console.log('MetaMask useWallet activate');
     console.log('MetaMask useWallet metamaskProvider', metamaskProvider);
+    if (!isInstalled) {
+      console.log('MetaMask useWallet not installed');
+      return;
+    }
+
+    console.log('MetaMask useWallet activate');
 
     // It's a workaround to fix the issue with opening Coinbase Wallet when it's also installed
     if (metamaskProvider && typeof ethereum.setSelectedProvider === 'function') {
@@ -57,7 +62,7 @@ export const useWallet: UseWalletType = () => {
       console.log('MetaMask useWallet deactivate');
       deactivate();
     };
-  }, [activate, deactivate]);
+  }, [activate, deactivate, ethereum, isInstalled, metamaskProvider]);
 
   return {account, accountHex: account, isInstalled, signChallenge};
 };

--- a/packages/app/src/wallets/metamask/useWallet.tsx
+++ b/packages/app/src/wallets/metamask/useWallet.tsx
@@ -32,9 +32,9 @@ export const useWallet: UseWalletType = () => {
     console.log('MetaMask useWallet metamaskProvider', metamaskProvider);
 
     // It's a workaround to fix the issue with opening Coinbase Wallet when it's also installed
-    if (metamaskProvider && typeof ethereum.selectedProvider !== 'undefined') {
+    if (metamaskProvider && typeof ethereum.setSelectedProvider === 'function') {
       try {
-        ethereum.selectedProvider = metamaskProvider;
+        ethereum.setSelectedProvider?.(metamaskProvider);
       } catch (err) {
         console.log('MetaMask useWallet selectedProvider err', err);
       }

--- a/packages/app/src/wallets/polkadot/useWallet.tsx
+++ b/packages/app/src/wallets/polkadot/useWallet.tsx
@@ -13,6 +13,8 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   const selectedAccount = accounts.find((account) => account.address === _selectedAccount);
   console.log('useWallet', {accounts, selectedAccount});
 
+  const isInstalled = !!(window as any)?.injectedWeb3?.['polkadot-js'];
+
   useEffect(() => {
     const enable = async () => {
       console.log('web3Enable start');
@@ -80,6 +82,7 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   return {
     account,
     accountHex,
+    isInstalled,
     content,
     signChallenge
   };

--- a/packages/app/src/wallets/polkadot/useWallet.tsx
+++ b/packages/app/src/wallets/polkadot/useWallet.tsx
@@ -16,6 +16,11 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   const isInstalled = !!(window as any)?.injectedWeb3?.['polkadot-js'];
 
   useEffect(() => {
+    if (!isInstalled) {
+      console.log('Polkadot.js Wallet is not installed');
+      return;
+    }
+
     const enable = async () => {
       console.log('web3Enable start');
       await web3Enable(appVariables.POLKADOT_CONNECTION_STRING);
@@ -26,7 +31,7 @@ export const useWallet: UseWalletType = ({appVariables}) => {
     };
 
     enable();
-  }, [appVariables]);
+  }, [appVariables, isInstalled]);
 
   const signChallenge = async (challenge: string): Promise<string> => {
     if (!selectedAccount) {

--- a/packages/app/src/wallets/talisman/useWallet.tsx
+++ b/packages/app/src/wallets/talisman/useWallet.tsx
@@ -27,6 +27,8 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   const selectedAccount = accounts.find((account) => account.address === _selectedAccount);
   console.log('useWallet', {accounts, selectedAccount});
 
+  const isInstalled = !!(window as any)?.talismanEth;
+
   useEffect(() => {
     const enable = async () => {
       console.log('web3Enable start');
@@ -110,6 +112,7 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   return {
     account,
     accountHex,
+    isInstalled,
     content,
     signChallenge
   };

--- a/packages/app/src/wallets/talisman/useWallet.tsx
+++ b/packages/app/src/wallets/talisman/useWallet.tsx
@@ -30,6 +30,11 @@ export const useWallet: UseWalletType = ({appVariables}) => {
   const isInstalled = !!(window as any)?.talismanEth;
 
   useEffect(() => {
+    if (!isInstalled) {
+      console.log('Talisman Wallet is not installed');
+      return;
+    }
+
     const enable = async () => {
       console.log('web3Enable start');
       await web3Enable(appVariables.POLKADOT_CONNECTION_STRING);
@@ -40,7 +45,7 @@ export const useWallet: UseWalletType = ({appVariables}) => {
     };
 
     enable();
-  }, [appVariables]);
+  }, [appVariables, isInstalled]);
 
   const signChallenge = async (challenge: string): Promise<string> => {
     if (!selectedAccount) {

--- a/packages/app/src/wallets/wallets.types.ts
+++ b/packages/app/src/wallets/wallets.types.ts
@@ -3,6 +3,7 @@ import {ReactNode} from 'react';
 export interface UseWalletHookReturnInterface {
   account: string | null | undefined;
   accountHex: string | null | undefined;
+  isInstalled: boolean;
   content?: ReactNode;
   signChallenge: (challenge: string) => Promise<string>;
 }


### PR DESCRIPTION
We can now detect whether each wallet type is installed.

There's also small fix for the way of pre-setting Metamask when it's chosen - the old way forced showing the right extension but broke somehow the way it works and it wouldn't detect changing of account inside Metamask