### PR TITLE
feat(world3d): util funcs for Vector3<->Position conversion, send proper data to BE

### DIFF
--- a/packages/odyssey3d/src/babylon/ObjectHelper.ts
+++ b/packages/odyssey3d/src/babylon/ObjectHelper.ts
@@ -16,7 +16,7 @@ import {Object3dInterface, Texture3dInterface, ClickPositionInterface} from '@mo
 
 import {PlayerHelper} from './PlayerHelper';
 import {SkyboxHelper} from './SkyboxHelper';
-import {getAssetFileName} from './UtilityHelper';
+import {getAssetFileName, posToVec3} from './UtilityHelper';
 
 interface BabylonObjectInterface {
   container: AssetContainer;
@@ -153,9 +153,7 @@ export class ObjectHelper {
     const node = instance.rootNodes[0];
     node.name = object.name;
 
-    node.position.x = object.transform.position.x;
-    node.position.y = object.transform.position.y;
-    node.position.z = object.transform.position.z;
+    node.position = posToVec3(object.transform.position);
     node.metadata = object.id;
     if (this.firstID === '') {
       this.firstID = object.id;

--- a/packages/odyssey3d/src/babylon/PlayerHelper.ts
+++ b/packages/odyssey3d/src/babylon/PlayerHelper.ts
@@ -17,7 +17,7 @@ import {
 } from '@momentum-xyz/core';
 
 import {ObjectHelper} from './ObjectHelper';
-import {getAssetFileName} from './UtilityHelper';
+import {getAssetFileName, posToVec3, vec3ToPos} from './UtilityHelper';
 
 const NORMAL_SPEED = 0.5;
 const FAST_SPEED = 1.5;
@@ -86,12 +86,9 @@ export class PlayerHelper {
       // TODO: Consider where to apply the offset between player and camera
 
       const playerTransform: TransformNoScaleInterface = {
-        position: Vector3.Zero(),
-        rotation: Vector3.Zero()
+        position: vec3ToPos(this.camera.position.subtract(PLAYER_OFFSET)),
+        rotation: vec3ToPos(this.camera.rotation)
       };
-
-      playerTransform.position = this.camera.position.subtract(PLAYER_OFFSET);
-      playerTransform.rotation = this.camera.rotation;
 
       if (onMove) {
         onMove(playerTransform);
@@ -194,10 +191,8 @@ export class PlayerHelper {
 
       const userNode = instance.rootNodes[0];
       userNode.name = user.name;
-      if (user.transform) {
-        userNode.position.x = user.transform?.position.x;
-        userNode.position.y = user.transform?.position.y;
-        userNode.position.z = user.transform?.position.z;
+      if (user.transform?.position) {
+        userNode.position = posToVec3(user.transform.position);
       }
 
       userNode.metadata = user.id;
@@ -226,13 +221,8 @@ export class PlayerHelper {
 
         const transformNode = userObj.userInstance.rootNodes[0];
 
-        transformNode.position.x = user.transform.position.x;
-        transformNode.position.y = user.transform.position.y;
-        transformNode.position.z = user.transform.position.z;
-
-        transformNode.rotation.x = user.transform.rotation.x;
-        transformNode.rotation.y = user.transform.rotation.y;
-        transformNode.rotation.z = user.transform.rotation.z;
+        transformNode.position = posToVec3(user.transform.position);
+        transformNode.rotation = posToVec3(user.transform.rotation);
       }
     }
   }

--- a/packages/odyssey3d/src/babylon/UtilityHelper.ts
+++ b/packages/odyssey3d/src/babylon/UtilityHelper.ts
@@ -1,4 +1,4 @@
-import {TransformNode} from '@babylonjs/core';
+import {TransformNode, Vector3} from '@babylonjs/core';
 
 import {ObjectHelper} from './ObjectHelper';
 
@@ -14,3 +14,16 @@ export function getNodeFromId(id: string): TransformNode | undefined {
     return undefined;
   }
 }
+
+export function vec3ToPos(vec: Vector3) {
+  const {x, y, z} = vec;
+  return {
+    x,
+    y,
+    z
+  };
+}
+
+export const posToVec3 = (pos: {x: number; y: number; z: number}) => {
+  return new Vector3(pos.x, pos.y, pos.z);
+};

--- a/packages/odyssey3d/src/babylon/WorldCreatorHelper.ts
+++ b/packages/odyssey3d/src/babylon/WorldCreatorHelper.ts
@@ -1,7 +1,7 @@
-import {GizmoManager, Scene, TransformNode, Vector3} from '@babylonjs/core';
+import {GizmoManager, Scene, TransformNode} from '@babylonjs/core';
 import {ObjectTransformInterface} from '@momentum-xyz/core';
 
-import {getNodeFromId} from './UtilityHelper';
+import {getNodeFromId, vec3ToPos} from './UtilityHelper';
 
 export enum GizmoTypesEnum {
   Position,
@@ -36,14 +36,10 @@ export class WorldCreatorHelper {
   static subscribeForTransformUpdates(objectId: string, node: TransformNode) {
     const updateTransformCallback = () => {
       const myTransfrom: ObjectTransformInterface = {
-        position: Vector3.Zero(),
-        rotation: Vector3.Zero(),
-        scale: Vector3.Zero()
+        position: vec3ToPos(node.position),
+        rotation: vec3ToPos(node.rotation),
+        scale: vec3ToPos(node.scaling)
       };
-
-      myTransfrom.position = node.position;
-      myTransfrom.rotation = node.rotation;
-      myTransfrom.scale = node.scaling;
 
       // TODO: Check how often data should be sent to onObjectTransform
       this.onObjectTransform(objectId, myTransfrom);


### PR DESCRIPTION
It seems typescript allows assigning Vector3 instance to PositionInterface properties but converting them to JSON produces {_x,_y,_z, isDirty} instead of {x,y,z} that we need. That's why I'm adding explicit convert function to/from Vector3 - they should be used when passing position/rotation/scaling outside babylon module and when receiving data from outside - object transforms, etc.