### PR TITLE
fix: explorer with less then 12 worlds

### DIFF
--- a/packages/odyssey3d/src/babylon/UniverseBuilderHelper.ts
+++ b/packages/odyssey3d/src/babylon/UniverseBuilderHelper.ts
@@ -392,7 +392,7 @@ export class UniverseBuilderHelper {
       if (odysseysInThisRing <= 0) {
         return;
       }
-      totalOdysseys = totalOdysseys - odysseysInThisRing;
+      odysseysInThisRing = Math.min(totalOdysseys, odysseysInThisRing);
 
       // Build the ring.
       const newRing: TransformNode = this.buildRing(
@@ -407,6 +407,7 @@ export class UniverseBuilderHelper {
       AllOdysseyRings.push(newRing);
       zValueRing = zValueRing * 1.2;
 
+      totalOdysseys = totalOdysseys - odysseysInThisRing;
       if (totalOdysseys >= halfAmountOfOdysseys) {
         // prepare amount for the next ring.
         odysseysInThisRing = Math.floor(odysseysInThisRing * 1.2);


### PR DESCRIPTION
Avoid passing in a negative number to buildRing.