### PR TITLE
Wait Babylon scene becomes ready and events handlers attached before sending events

### DIFF
--- a/packages/app/src/scenes/map3d/pages/Map3dPage/Map3dPage.tsx
+++ b/packages/app/src/scenes/map3d/pages/Map3dPage/Map3dPage.tsx
@@ -1,4 +1,4 @@
-import {FC, useEffect, useRef} from 'react';
+import {FC, useEffect, useRef, useState} from 'react';
 import {observer} from 'mobx-react-lite';
 import {Universe3dEmitter} from '@momentum-xyz/core';
 import {UniverseScene} from '@momentum-xyz/odyssey3d';
@@ -13,6 +13,8 @@ const Map3dPage: FC = () => {
   const {widgetManagerStore, universeStore} = useStore();
   const {allWorlds, allUsers} = universeStore.universe2dStore;
 
+  const [readyToHandleEvents, setReadyToHandleEvents] = useState<boolean>(false);
+
   // FIXME: Workaround to prevent sending twice lists
   const usersWereInitialised = useRef<boolean>(false);
   const worldsWereInitialised = useRef<boolean>(false);
@@ -24,7 +26,18 @@ const Map3dPage: FC = () => {
   }, [widgetManagerStore]);
 
   useEffect(() => {
-    console.log('Map3dPage: useEffect', allWorlds, allUsers);
+    console.log(
+      'Map3dPage: useEffect',
+      allWorlds,
+      allUsers,
+      usersWereInitialised.current,
+      worldsWereInitialised.current,
+      readyToHandleEvents
+    );
+    if (!readyToHandleEvents) {
+      return;
+    }
+
     if (allWorlds.length > 0 && !usersWereInitialised.current) {
       usersWereInitialised.current = true;
       Universe3dEmitter.emit(
@@ -50,7 +63,7 @@ const Map3dPage: FC = () => {
         }))
       );
     }
-  }, [allWorlds, allUsers, allUsers.length, allWorlds.length]);
+  }, [allWorlds, allUsers, allUsers.length, allWorlds.length, readyToHandleEvents]);
 
   return (
     <UniverseScene
@@ -67,6 +80,10 @@ const Map3dPage: FC = () => {
       }}
       onClickOutside={() => {
         //widgetManagerStore.closeAll();
+      }}
+      onReadyToHandleEvents={() => {
+        console.log('Map3dPage: onReadyToHandleEvents');
+        setReadyToHandleEvents(true);
       }}
     />
   );

--- a/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
+++ b/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
@@ -1,4 +1,4 @@
-import {FC, useEffect, useMemo} from 'react';
+import {FC, useEffect, useMemo, useState} from 'react';
 import {observer} from 'mobx-react-lite';
 import {toast} from 'react-toastify';
 import {generatePath, matchPath, useNavigate, useLocation} from 'react-router-dom';
@@ -21,6 +21,7 @@ import {HighFiveContent, TOAST_BASE_OPTIONS} from 'ui-kit';
 const WorldPage: FC = () => {
   const {agoraStore, universeStore, widgetsStore, widgetManagerStore, sessionStore} = useStore();
   const {world3dStore} = universeStore;
+  const [readyToHandleEvents, setReadyToHandleEvents] = useState<boolean>(false);
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -52,7 +53,7 @@ const WorldPage: FC = () => {
   }, [worldId, agoraStore, widgetManagerStore]);
 
   useEffect(() => {
-    if (worldId) {
+    if (worldId && readyToHandleEvents) {
       const teleportToWorld = () => {
         if (!PosBusService.isConnected()) {
           console.log(`BabylonPage: PosBusService is not connected.`);
@@ -71,7 +72,7 @@ const WorldPage: FC = () => {
     return () => {
       universeStore.leaveWorld();
     };
-  }, [worldId, universeStore]);
+  }, [worldId, universeStore, readyToHandleEvents]);
 
   const handleObjectClick = (objectId: string, clickPos: ClickPositionInterface) => {
     if (universeStore.isCreatorMode) {
@@ -215,6 +216,9 @@ const WorldPage: FC = () => {
       onUserClick={handleUserClick}
       onClickOutside={handleClickOutside}
       onBumpReady={handleBumpReady}
+      onReadyToHandleEvents={() => {
+        setReadyToHandleEvents(true);
+      }}
     />
   );
 };

--- a/packages/odyssey3d/src/Emulator.tsx
+++ b/packages/odyssey3d/src/Emulator.tsx
@@ -85,6 +85,7 @@ const WorldEmulator: FC = () => {
       onUserClick={(e) => console.log('onUserClick', e)}
       onClickOutside={() => console.log('onClickOutside')}
       onBumpReady={() => console.log('onBumpReady')}
+      onReadyToHandleEvents={() => console.log('onReadyToHandleEvents')}
     />
   );
 };
@@ -120,6 +121,7 @@ const UniverseEmulator = () => {
       onWorldClick={(e) => console.log('onWorldClick', e)}
       onUserClick={(e) => console.log('onUserClick', e)}
       onClickOutside={() => console.log('onClickOutside')}
+      onReadyToHandleEvents={() => console.log('onReadyToHandleEvents')}
     />
   );
 };

--- a/packages/odyssey3d/src/core/interfaces/odyssey3d.interface.ts
+++ b/packages/odyssey3d/src/core/interfaces/odyssey3d.interface.ts
@@ -28,4 +28,6 @@ export interface Odyssey3dPropsInterface {
   onMove: (transform: TransformNoScaleInterface) => void;
 
   onBumpReady: () => void;
+
+  onReadyToHandleEvents: () => void;
 }

--- a/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -14,9 +14,9 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
   const onMove = useMutableCallback(callbacks.onMove);
   const onObjectTransform = useMutableCallback(callbacks.onObjectTransform);
   const onClickOutside = useMutableCallback(callbacks.onClickOutside);
+  const onReadyToHandleEvents = useMutableCallback(callbacks.onReadyToHandleEvents);
   // Sent from user1 to BE to trigger sparkles
   const onBumpReady = useMutableCallback(callbacks.onBumpReady);
-  // TODO handle it
 
   useEffect(() => {
     return () => {
@@ -124,6 +124,8 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
       events.on('TriggerBump', (userId) => {
         PlayerHelper.followPlayer(userId);
       });
+
+      onReadyToHandleEvents();
     } else {
       console.error('There is no canvas for Babylon.');
     }

--- a/packages/odyssey3d/src/scenes/UniverseScene/UniverseScene.tsx
+++ b/packages/odyssey3d/src/scenes/UniverseScene/UniverseScene.tsx
@@ -14,12 +14,14 @@ export interface PropsInterface {
   onWorldClick: (id: string) => void;
   onUserClick: (id: string) => void;
   onClickOutside: () => void;
+  onReadyToHandleEvents: () => void;
 }
 
 export const UniverseScene: FC<PropsInterface> = ({events, renderURL, ...callbacks}) => {
   const onWorldClick = useMutableCallback(callbacks.onWorldClick);
   const onUserClick = useMutableCallback(callbacks.onUserClick);
   const onClickOutside = useMutableCallback(callbacks.onClickOutside);
+  const onReadyToHandleEvents = useMutableCallback(callbacks.onReadyToHandleEvents);
 
   useEffect(() => {
     return () => {
@@ -69,6 +71,8 @@ export const UniverseScene: FC<PropsInterface> = ({events, renderURL, ...callbac
     events.on('WorldSelected', (id) => {
       console.log('Babylon: WorldSelected ', id);
     });
+
+    onReadyToHandleEvents();
 
     PlayerHelper.spawnPlayer(scene);
 


### PR DESCRIPTION
It helps to avoid race condition between babylon scene becoming ready and events that we send it - no we wait before sending events and signalling teleport in posbus.

Going from universe to world then universe then world again is broken in the controller.