### PR TITLE
Creator - keep the selected object and tabs - move camera and fly around

### DIFF
--- a/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
+++ b/packages/app/src/scenes/world/pages/WorldPage/WorldPage.tsx
@@ -114,7 +114,10 @@ const WorldPage: FC = () => {
 
   const handleClickOutside = () => {
     console.log('BabylonPage: handleClickOutside');
-    world3dStore?.closeAndResetObjectMenu();
+    if (creatorStore.selectedTab === 'gizmo') {
+      // deselect only with gizmo - other tabs have closing button
+      world3dStore?.closeAndResetObjectMenu();
+    }
   };
 
   const handleUserClick = (id: string, clickPosition: ClickPositionInterface) => {


### PR DESCRIPTION
…izmo selected

It allows flying around and moving camera without losing current creator context