### PR TITLE
fix(3d): avoid duplicate objects on reconnect

### DIFF
--- a/packages/odyssey3d/src/babylon/ObjectHelper.ts
+++ b/packages/odyssey3d/src/babylon/ObjectHelper.ts
@@ -13,7 +13,12 @@ import {
   Texture
 } from '@babylonjs/core';
 import '@babylonjs/loaders/glTF';
-import {Object3dInterface, Texture3dInterface, ClickPositionInterface} from '@momentum-xyz/core';
+import {
+  Object3dInterface,
+  Texture3dInterface,
+  ClickPositionInterface,
+  SetWorldInterface
+} from '@momentum-xyz/core';
 
 import {PlayerHelper} from './PlayerHelper';
 import {SkyboxHelper} from './SkyboxHelper';
@@ -99,10 +104,8 @@ export class ObjectHelper {
     };
   }
 
-  static setWorld(assetID: string) {
-    // TODO: Add logic with this assetid
-    const assetUrl = getAssetFileName(assetID);
-    console.log('assetID is: ' + assetUrl);
+  static setWorld(world: SetWorldInterface) {
+    this.disposeAllObjects();
   }
 
   static async spawnObjectAsync(scene: Scene, object: Object3dInterface, attachToCam: boolean) {

--- a/packages/odyssey3d/src/babylon/PlayerHelper.ts
+++ b/packages/odyssey3d/src/babylon/PlayerHelper.ts
@@ -66,6 +66,7 @@ export class PlayerHelper {
   static userMap = new Map<string, BabylonUserInterface>();
 
   static playerInstance: InstantiatedEntries;
+  static playerContainer: AssetContainer;
   static playerAvatar3D: string;
   static playerId: string;
   static playerInterface: Odyssey3dUserInterface;
@@ -133,6 +134,11 @@ export class PlayerHelper {
   }
 
   static setWorld(world: SetWorldInterface, userId: string) {
+    this.disposeAllUsers();
+    this.playerInstance?.dispose();
+    this.playerContainer?.removeAllFromScene();
+    this.playerContainer?.dispose();
+
     this.playerAvatar3D = world.avatar_3d_asset_id;
     this.playerId = userId;
     this.spawnPlayer(PlayerHelper.scene);
@@ -196,6 +202,7 @@ export class PlayerHelper {
     instance.animationGroups[4].play();
 
     this.playerInstance = instance;
+    this.playerContainer = container;
   }
 
   static setUserAvatar(node: TransformNode) {

--- a/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/odyssey3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -65,6 +65,7 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
       events.on('SetWorld', (world, userId) => {
         //CameraHelper.spawnPlayer(scene, assetID);
         PlayerHelper.setWorld(world, userId);
+        ObjectHelper.setWorld(world);
       });
 
       events.on('AddObject', async (object, attachToCamera = false) => {


### PR DESCRIPTION
Backend controller restart, posbus client reconnects and new world state is send.


This fixes having duplicate objects in the world (or leaving them in memory), by removing objects/users when  SetWorld is received. These are then filled backend by the addUser and addObject messages.

So restart makes it recreate the world. Seem to be alright with my limited tested. You notice it removing and adding everything, but it pretty fast (since data has been cached by browser). So it feels like a short 'glitch'.