### PR TITLE
fix(online-users): reset list on posbus reconnect

### DIFF
--- a/packages/app/src/stores/UniverseStore/models/World2dStore/World2dStore.ts
+++ b/packages/app/src/stores/UniverseStore/models/World2dStore/World2dStore.ts
@@ -28,6 +28,9 @@ const World2dStore = types.compose(
         Event3dEmitter.on('UserRemoved', (userId) => {
           this.removeOnlineUser(userId);
         });
+        Event3dEmitter.on('SetWorld', (world, userId) => {
+          this.removeAllOnlineUsers();
+        });
       },
       addOnlineUser(userId: string) {
         if (!self.onlineUsersList.find((u) => u.userId === userId)) {
@@ -39,6 +42,9 @@ const World2dStore = types.compose(
         self.onlineUsersList = cast([
           ...self.onlineUsersList.filter((user) => user.userId !== userId)
         ]);
+      },
+      removeAllOnlineUsers() {
+        self.onlineUsersList = cast([]);
       }
     }))
     .views((self) => ({


### PR DESCRIPTION
The '2d' variant of https://github.com/momentum-xyz/ui-client/pull/845

When backend controller connection is lost, we reconnect.
Reset the state of online users when we receive a SetWorld message.
