### PR TITLE
fix: remove event3d listeners when switching world

### DIFF
--- a/packages/app/src/stores/AgoraStore/models/AgoraVoiceChatStore/AgoraVoiceChatStore.ts
+++ b/packages/app/src/stores/AgoraStore/models/AgoraVoiceChatStore/AgoraVoiceChatStore.ts
@@ -76,6 +76,10 @@ const AgoraVoiceChatStore = types
     subscribeToPosBusUsers() {
       Event3dEmitter.on('UserJoinedVoiceChat', this.handleAddUser);
       Event3dEmitter.on('UserLeftVoiceChat', this.handleRemoveUser);
+    },
+    beforeDestroy() {
+      Event3dEmitter.off('UserJoinedVoiceChat', this.handleAddUser);
+      Event3dEmitter.off('UserLeftVoiceChat', this.handleRemoveUser);
     }
   }))
   .actions((self) => ({


### PR DESCRIPTION
Bit of a 'prelude' to switching worlds without refreshing/reloading everything.

Gives me errors/warnings and makes debugging switching worlds harder.
Cleanup the listeners in mobx-state-tree lifecycle hooks.