### PR TITLE
Feature/gltf mesh compression

### DIFF
--- a/packages/odyssey3d/package.json
+++ b/packages/odyssey3d/package.json
@@ -27,6 +27,7 @@
     "axios": "^0.22.0",
     "babylonjs-hook": "^0.1.1",
     "date-fns-tz": "^1.3.4",
+    "meshoptimizer": "^0.19.0",
     "mkdirp": "^1.0.4",
     "mobx": "^6.4.2",
     "mobx-react-lite": "^3.3.0",

--- a/packages/odyssey3d/src/babylon/ObjectHelper.ts
+++ b/packages/odyssey3d/src/babylon/ObjectHelper.ts
@@ -10,9 +10,11 @@ import {
   Color3,
   Nullable,
   Vector3,
-  Texture
+  Texture,
+  DracoCompression
 } from '@babylonjs/core';
 import '@babylonjs/loaders/glTF/2.0/glTFLoader';
+import '@babylonjs/loaders/glTF/2.0/Extensions/index';
 import {
   Object3dInterface,
   Texture3dInterface,
@@ -25,6 +27,14 @@ import {SkyboxHelper} from './SkyboxHelper';
 import {getAssetFileName} from './UtilityHelper';
 import {posToVec3} from './TransformHelper';
 import {WorldCreatorHelper} from './WorldCreatorHelper';
+
+// TODO: Bundle and serve these ourself.
+const DRACO_CDN = 'https://www.gstatic.com/draco/versioned/decoders/1.5.6/';
+DracoCompression.Configuration.decoder = {
+  wasmUrl: DRACO_CDN + 'draco_wasm_wrapper_gltf.js',
+  wasmBinaryUrl: DRACO_CDN + 'draco_decoder_gltf.wasm',
+  fallbackUrl: DRACO_CDN + 'draco_decoder_gltf.js'
+};
 
 interface BabylonObjectInterface {
   container: AssetContainer;

--- a/packages/odyssey3d/src/babylon/ObjectHelper.ts
+++ b/packages/odyssey3d/src/babylon/ObjectHelper.ts
@@ -11,7 +11,8 @@ import {
   Nullable,
   Vector3,
   Texture,
-  DracoCompression
+  DracoCompression,
+  MeshoptCompression
 } from '@babylonjs/core';
 import '@babylonjs/loaders/glTF/2.0/glTFLoader';
 import '@babylonjs/loaders/glTF/2.0/Extensions/index';
@@ -34,6 +35,9 @@ DracoCompression.Configuration.decoder = {
   wasmUrl: DRACO_CDN + 'draco_wasm_wrapper_gltf.js',
   wasmBinaryUrl: DRACO_CDN + 'draco_decoder_gltf.wasm',
   fallbackUrl: DRACO_CDN + 'draco_decoder_gltf.js'
+};
+MeshoptCompression.Configuration.decoder = {
+  url: new URL('meshoptimizer/meshopt_decoder.js', import.meta.url).toString()
 };
 
 interface BabylonObjectInterface {

--- a/packages/odyssey3d/src/babylon/ObjectHelper.ts
+++ b/packages/odyssey3d/src/babylon/ObjectHelper.ts
@@ -12,7 +12,7 @@ import {
   Vector3,
   Texture
 } from '@babylonjs/core';
-import '@babylonjs/loaders/glTF';
+import '@babylonjs/loaders/glTF/2.0/glTFLoader';
 import {
   Object3dInterface,
   Texture3dInterface,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15025,6 +15025,11 @@ merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+meshoptimizer@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-0.19.0.tgz#1669e6d788ad3ffd238a65184e478355642ca979"
+  integrity sha512-58qz5Qc/6Geu8Ib3bBWERE5R7pM5ErrJVo16fAtu6ryxVaE3VAtM/u2vurDxaq8AGZ3yWxuM/DnylTga5a4XCQ==
+
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"


### PR DESCRIPTION
Tested some glb files with mesh compression and how babylon processes these.
Couple of changes:
- Change loader, to explicitly the glTF 2 one. So this will drop gltf 1, obj and STL support.
Mainly to avoid we ever accidentally get worlds using these (and having to support it forever).
- Explicitly configure the 'decoders', these are WASM 'blobs' that get loaded from an URL (draco uses a worker thread default). These default to 'preview.babylonjs.com' (not cdn.babylonjs). Changed these to versioned urls (unfortunately the draco library doesn't publish on official npm, only versioned CDN)


