### PR TITLE
Feature/posbus object attr changes

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "@headlessui/react": "^1.2.0",
     "@momentum-xyz/core": "^0.1.2",
     "@momentum-xyz/core3d": "^0.1.0",
-    "@momentum-xyz/posbus-client": "0.0.1-beta.1",
+    "@momentum-xyz/posbus-client": "0.0.1-beta.2",
     "@momentum-xyz/sdk": "^0.1.5",
     "@momentum-xyz/ui-kit": "^0.1.4",
     "@polkadot/api": "8.10.1",

--- a/packages/app/src/core/types/posBusMessage.type.ts
+++ b/packages/app/src/core/types/posBusMessage.type.ts
@@ -1,6 +1,4 @@
-import {VoiceChatActionAttributeInterface, VoiceChatUserAttributeInterface} from 'api/interfaces';
-import {BroadcastStatusEnum, PosBusMessageTypeEnum, PosBusStatusEnum} from 'core/enums';
-import {PosBusAttributeMessageDataType} from 'core/types';
+import {BroadcastStatusEnum, PosBusStatusEnum} from 'core/enums';
 
 export type PosBusMessageStatusType = {
   status: PosBusStatusEnum;
@@ -91,21 +89,4 @@ export type PosBusFlyToMeType = {
 
 export type PosBusScreenShareMessageType = {
   spaceId: string;
-};
-
-// NEW CONTROLLER MESSAGES
-
-export type PosBusMiroStateMessageType = {
-  type: PosBusMessageTypeEnum;
-  data: PosBusAttributeMessageDataType<unknown>;
-};
-
-export type PosBusVoiceChatActionMessageType = {
-  type: PosBusMessageTypeEnum;
-  data: PosBusAttributeMessageDataType<VoiceChatActionAttributeInterface>;
-};
-
-export type PosBusVoiceChatUserMessageType = {
-  type: PosBusMessageTypeEnum;
-  data: PosBusAttributeMessageDataType<VoiceChatUserAttributeInterface>;
 };

--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -54,7 +54,7 @@ class PosBusService {
   static connect(client: Client, token: string, userId: string) {
     return client.connect(`${appVariables.BE_URL}/posbus`, token, userId).then((port) => {
       this.main.port = port;
-      port.onmessage = PosBusService.handleIncomingMessage;
+      port.onmessage = (msg) => PosBusService.handleIncomingMessage(msg);
     });
   }
 

--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -1,4 +1,4 @@
-import {AttributeNameEnum, AttributeValueInterface} from '@momentum-xyz/sdk';
+import {AttributeNameEnum} from '@momentum-xyz/sdk';
 import {
   Client,
   loadClientWorker,
@@ -14,8 +14,6 @@ import {
 import {AttributeValueChanged} from '@momentum-xyz/posbus-client/dist/build/posbus';
 
 import {PosBusEventEmitter} from 'core/constants';
-import {PosBusMessageTypeEnum} from 'core/enums';
-import {PosBusMiroStateMessageType as PosBusAttributeMessageType} from 'core/types';
 import {appVariables} from 'api/constants';
 import {PluginIdEnum} from 'api/enums';
 
@@ -324,45 +322,6 @@ class PosBusService {
 
   static unsubscribe(topic: string) {
     this.main._subscribedAttributeTypeTopics.delete(topic);
-  }
-
-  static handleSpaceAttributeMessage(target: string, message: PosBusAttributeMessageType) {
-    switch (message.type) {
-      case PosBusMessageTypeEnum.ATTRIBUTE_CHANGED:
-        PosBusEventEmitter.emit(
-          'space-attribute-changed',
-          target,
-          message.data.attribute_name,
-          message.data.value as AttributeValueInterface
-        );
-        break;
-      case PosBusMessageTypeEnum.ATTRIBUTE_REMOVED:
-        PosBusEventEmitter.emit('space-attribute-removed', target, message.data.attribute_name);
-        break;
-      case PosBusMessageTypeEnum.SUB_ATTRIBUTE_CHANGED:
-        if (!message.data.sub_name) {
-          return;
-        }
-        PosBusEventEmitter.emit(
-          'space-attribute-item-changed',
-          target,
-          message.data.attribute_name,
-          message.data.sub_name,
-          message.data.value
-        );
-        break;
-      case PosBusMessageTypeEnum.SUB_ATTRIBUTE_REMOVED:
-        if (!message.data.sub_name) {
-          return;
-        }
-        PosBusEventEmitter.emit(
-          'space-attribute-item-removed',
-          target,
-          message.data.attribute_name,
-          message.data.sub_name
-        );
-        break;
-    }
   }
 }
 


### PR DESCRIPTION
Adapt to a change in posbus message format for attribute changes.

This only contains 'refactoring' around this, nothing functional changes here.
But the end goal here is: changing an attribute on a specific object, the frontend should be able know which object it was. So an extra field was added. Tried to do it backwards compatible, but my eyes started bleeding. So refactored ;p

This can only be merged after https://github.com/momentum-xyz/posbus-client/pull/37 and https://github.com/momentum-xyz/ubercontroller/pull/173
And then the posbus-client dependency can be updated, so ignore the missing lock-file change, since that has not been build+published yet.