### PR TITLE
fix(3d): invisible object when setting texture

### DIFF
--- a/packages/core3d/src/babylon/ObjectHelper.ts
+++ b/packages/core3d/src/babylon/ObjectHelper.ts
@@ -84,8 +84,9 @@ export class ObjectHelper {
     }
 
     // Handle textures arriving before objects are spawned.
-    if (this.objectsMap.has(texture.objectId)) {
+    if (!this.objectsMap.has(texture.objectId)) {
       this.awaitingTexturesMap.set(texture.objectId, texture);
+      return;
     }
 
     // Handle object color
@@ -108,7 +109,7 @@ export class ObjectHelper {
           const textureUrl = this.textureRootUrl + this.textureDefaultSize + texture.hash;
           const newTexture = new Texture(
             textureUrl,
-            undefined,
+            scene,
             undefined,
             undefined,
             undefined,


### PR DESCRIPTION
Two things:
If the object doesn't exist yet: do not continue trying (it is handled in the createObject).

When setting a texture, then object becomes invisible. Looks like adding the scene object fixes this.