### PR TITLE
fix(3d): object textures on initial load

### DIFF
--- a/packages/core/src/interfaces/texture.interface.ts
+++ b/packages/core/src/interfaces/texture.interface.ts
@@ -1,5 +1,5 @@
 export interface Texture3dInterface {
   objectId: string;
   hash: string;
-  label?: string;
+  label: string;
 }

--- a/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -1,6 +1,7 @@
 import {FC, useEffect} from 'react';
 import {Scene} from '@babylonjs/core';
 import SceneComponent from 'babylonjs-hook';
+import {Texture3dInterface} from '@momentum-xyz/core';
 import {useMutableCallback} from '@momentum-xyz/ui-kit';
 
 import {Odyssey3dPropsInterface} from '../../core/interfaces';
@@ -93,8 +94,8 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
         ObjectHelper.removeObject(objectId);
       });
 
-      events.on('ObjectTextureChanged', (object) => {
-        ObjectHelper.setObjectTexture(scene, object);
+      events.on('ObjectTextureChanged', (object: Texture3dInterface) => {
+        ObjectHelper.objectTextureChange(scene, object);
       });
 
       events.on('ObjectTransform', (id, object) => {


### PR DESCRIPTION
Fix setting the textures on objects that are (async) loading.

Problem is when a object has both a 'color' and a 'image' texture. One of the two got applied, depending on the incoming ordering. 

Also a bit of of UI problem, since they set in different places, are not mutually exclusive and can't be removed. 
We'll fix this in upcoming changes of the design of this flow.

Refactors the flow a bit, extract the waiting bits and then make both existing and new objects call into the same path.
And allows multiple 'texture' slot/labels now, to handle the colors (and allows multiple slots/label per object in the future).

https://momentum.nifty.pm/Yok8v8pw_pmY/task/DEV-320