### PR TITLE
fix(creator): deselect object before spawning a new one

### DIFF
--- a/packages/app/src/scenes/widgets/stores/CreatorStore/models/SpawnAssetStore/SpawnAssetStore.ts
+++ b/packages/app/src/scenes/widgets/stores/CreatorStore/models/SpawnAssetStore/SpawnAssetStore.ts
@@ -183,6 +183,7 @@ const SpawnAssetStore = types
       const objectId = response?.object_id;
 
       if (objectId) {
+        getRootStore(self).universeStore.world3dStore?.closeAndResetObjectMenu();
         getRootStore(self).universeStore.world3dStore?.setAttachedToCamera(objectId);
       }
 


### PR DESCRIPTION
When a new object is spawn it gets attached to the camera and needs to be dropped then by pressing a button.

If another object was selected before that, it remains selected and confirm button for the spawned object is never shown.