### PR TITLE
Fix/members 403s

### DIFF
--- a/packages/app/src/api/repositories/worldRepository/worldRepository.api.types.ts
+++ b/packages/app/src/api/repositories/worldRepository/worldRepository.api.types.ts
@@ -21,6 +21,7 @@ export interface WorldInterface {
   owner_name?: string | null;
   stake_total?: string | null;
   stakers: WorldStakerInterface[] | null;
+  is_admin?: boolean;
 }
 
 export interface WorldStakerInterface {

--- a/packages/app/src/core/models/World/World.ts
+++ b/packages/app/src/core/models/World/World.ts
@@ -16,7 +16,8 @@ const World = types
     owner_id: types.string,
     owner_name: types.maybeNull(types.string),
     stake_total: types.maybeNull(types.string),
-    stakers: types.maybeNull(types.optional(types.array(WorldStaker), []))
+    stakers: types.maybeNull(types.optional(types.array(WorldStaker), [])),
+    is_admin: types.optional(types.boolean, false)
   })
   .views((self) => ({
     get imageSrc(): string | null {

--- a/packages/app/src/core/models/WorldMembers/WorldMembers.ts
+++ b/packages/app/src/core/models/WorldMembers/WorldMembers.ts
@@ -55,11 +55,6 @@ const WorldMembers = types.compose(
         yield self.fetchMembers();
       })
     }))
-    .actions((self) => ({
-      afterCreate() {
-        self.fetchMembers();
-      }
-    }))
 );
 
 export type WorldMembersModelType = Instance<typeof WorldMembers>;

--- a/packages/app/src/stores/UniverseStore/models/World2dStore/World2dStore.ts
+++ b/packages/app/src/stores/UniverseStore/models/World2dStore/World2dStore.ts
@@ -63,14 +63,7 @@ const World2dStore = types.compose(
         return self.worldDetails?.world?.owner_id === getRootStore(self).sessionStore.userId;
       },
       get isCurrentUserWorldAdmin(): boolean {
-        return (
-          this.isMyWorld ||
-          // TODO world_details will have flag for admin, switch to it once ready
-          self.worldMembers?.members?.some(
-            (m) => m.user_id === getRootStore(self).sessionStore.userId
-          ) ||
-          false
-        );
+        return self.worldDetails?.world?.is_admin === true;
       },
       get image(): string | null {
         return self.worldDetails?.world?.avatarHash || null;


### PR DESCRIPTION
Fixes the annoying 403 popups :)

A follow up of the co-creator feature. Using the new 'is_admin' flag in the world details endpoint to avoid the 'member' calls (which are currently only allowed by admins themself).

https://momentum.nifty.pm/Yok8v8pw_pmY/task/DEV-438
and
https://momentum.nifty.pm/Yok8v8pw_pmY/task/DEV-397