### PR TITLE
Claimable objects: 3D effect when unclaimed

### DIFF
--- a/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttributes.api.ts
+++ b/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttributes.api.ts
@@ -61,12 +61,13 @@ export const deleteSpaceAttribute: RequestInterface<DeleteSpaceAttributeRequest,
 ) => {
   const {spaceId, plugin_id, attribute_name, ...restOptions} = options;
 
-  restOptions.data = {
-    plugin_id,
-    attribute_name
-  };
-
-  const url = generatePath(spaceAttributesRepositoryEndpoints().attributes, {spaceId});
+  const url =
+    generatePath(spaceAttributesRepositoryEndpoints().attributes, {spaceId}) +
+    '?' +
+    new URLSearchParams({
+      plugin_id,
+      attribute_name
+    });
 
   return request.delete(url, restOptions);
 };

--- a/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttributes.api.ts
+++ b/packages/app/src/api/repositories/spaceAttributeRepository/spaceAttributes.api.ts
@@ -61,13 +61,12 @@ export const deleteSpaceAttribute: RequestInterface<DeleteSpaceAttributeRequest,
 ) => {
   const {spaceId, plugin_id, attribute_name, ...restOptions} = options;
 
-  const url =
-    generatePath(spaceAttributesRepositoryEndpoints().attributes, {spaceId}) +
-    '?' +
-    new URLSearchParams({
-      plugin_id,
-      attribute_name
-    });
+  restOptions.params = {
+    plugin_id,
+    attribute_name
+  };
+
+  const url = generatePath(spaceAttributesRepositoryEndpoints().attributes, {spaceId});
 
   return request.delete(url, restOptions);
 };

--- a/packages/app/src/scenes/widgets/stores/CreatorStore/models/SpawnAssetStore/SpawnAssetStore.ts
+++ b/packages/app/src/scenes/widgets/stores/CreatorStore/models/SpawnAssetStore/SpawnAssetStore.ts
@@ -1,9 +1,11 @@
 import {cast, flow, types} from 'mobx-state-tree';
 import {ObjectTypeIdEnum, RequestModel, ResetModel} from '@momentum-xyz/core';
 import {ImageSizeEnum} from '@momentum-xyz/ui-kit';
+import {AttributeNameEnum} from '@momentum-xyz/sdk';
+import {EffectsEnum} from '@momentum-xyz/core3d';
 
 import {api, FetchAssets3dResponse, PostSpaceResponse, UploadAsset3dResponse} from 'api';
-import {Asset3dCategoryEnum} from 'api/enums';
+import {Asset3dCategoryEnum, PluginIdEnum} from 'api/enums';
 import {appVariables} from 'api/constants';
 import {Asset3d, Asset3dInterface, SearchQuery} from 'core/models';
 import {PosBusService} from 'shared/services';
@@ -26,6 +28,7 @@ const SpawnAssetStore = types
       uploadAssetRequest: types.optional(RequestModel, {}),
       fetchAssets3dRequest: types.optional(RequestModel, {}),
       spawnObjectRequest: types.optional(RequestModel, {}),
+      setEffectAttrRequest: types.optional(RequestModel, {}),
       setIsVisibleRequest: types.optional(RequestModel, {}),
 
       assets3d: types.array(Asset3d),
@@ -189,6 +192,15 @@ const SpawnAssetStore = types
 
       if (objectId) {
         getRootStore(self).universeStore.world3dStore?.setAttachedToCamera(objectId);
+
+        if (self.isCustomizable) {
+          yield self.setEffectAttrRequest.send(api.spaceAttributeRepository.setSpaceAttribute, {
+            spaceId: objectId,
+            plugin_id: PluginIdEnum.CORE,
+            attribute_name: AttributeNameEnum.OBJECT_EFFECT,
+            value: {value: EffectsEnum.TRANSPARENT}
+          });
+        }
       }
 
       return objectId;

--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -154,6 +154,10 @@ class PosBusService {
           });
         }
 
+        if (entries?.string?.object_effect) {
+          Event3dEmitter.emit('ObjectEffectChanged', id, entries.string.object_effect);
+        }
+
         if (entries?.audio?.spatial) {
           Event3dEmitter.emit('ObjectSoundChanged', id, {
             volume: entries.audio.spatial.volume || 0,

--- a/packages/core/src/services/event.emitter.ts
+++ b/packages/core/src/services/event.emitter.ts
@@ -27,6 +27,7 @@ export type Event3dType = {
   ObjectTransform: (objectId: string, transform: ObjectTransformInterface) => void;
   SetWorld: (world: SetWorldInterface, userId: string) => void;
   ObjectTextureChanged: (texture: Texture3dInterface) => void;
+  ObjectEffectChanged: (objectId: string, effect: string | null) => void;
 
   UserAdded: (user: Odyssey3dUserInterface) => void;
   UserRemoved: (userId: string) => void;

--- a/packages/core/src/services/event.emitter.ts
+++ b/packages/core/src/services/event.emitter.ts
@@ -27,7 +27,7 @@ export type Event3dType = {
   ObjectTransform: (objectId: string, transform: ObjectTransformInterface) => void;
   SetWorld: (world: SetWorldInterface, userId: string) => void;
   ObjectTextureChanged: (texture: Texture3dInterface) => void;
-  ObjectEffectChanged: (objectId: string, effect: string | null) => void;
+  ObjectEffectChanged: (objectId: string, effect: string) => void;
 
   UserAdded: (user: Odyssey3dUserInterface) => void;
   UserRemoved: (userId: string) => void;

--- a/packages/core3d/src/babylon/ObjectHelper.ts
+++ b/packages/core3d/src/babylon/ObjectHelper.ts
@@ -301,6 +301,12 @@ export class ObjectHelper {
     }
 
     this.mySpawningClone?.dispose();
+
+    const obj = this.objectsMap.get(this.selectedObjectFromSpawn);
+    if (obj && obj.effect && obj.effect !== EffectsEnum.NONE) {
+      this.setObjectEffect(this.selectedObjectFromSpawn, obj.effect, true);
+    }
+
     this.selectedObjectFromSpawn = '';
 
     PlayerHelper.setSelfPos(new Vector3(0, -0.5, -3));
@@ -336,7 +342,7 @@ export class ObjectHelper {
     }
   }
 
-  static setObjectEffect(objectId: string, effect: string) {
+  static setObjectEffect(objectId: string, effect: string, force = false) {
     console.log('setObjectEffect', objectId, effect);
     const obj = this.objectsMap.get(objectId);
     if (!obj) {
@@ -360,7 +366,7 @@ export class ObjectHelper {
       });
       console.log('setObjectEffect: original object is visible');
     } else if (effect === EffectsEnum.TRANSPARENT) {
-      if (obj.effect === effect) {
+      if (obj.effect === effect && !force) {
         return;
       }
       if (obj.cloneWithEffect) {

--- a/packages/core3d/src/babylon/ObjectHelper.ts
+++ b/packages/core3d/src/babylon/ObjectHelper.ts
@@ -19,6 +19,8 @@ import {
   SoundItemInterface
 } from '@momentum-xyz/core';
 
+import {EffectsEnum} from '../core/enums';
+
 import {PlayerHelper} from './PlayerHelper';
 import {SkyboxHelper} from './SkyboxHelper';
 import {getAssetFileName, getBoundingInfo} from './UtilityHelper';
@@ -31,7 +33,7 @@ interface BabylonObjectInterface {
   objectDefinition: Object3dInterface;
   objectInstance: InstantiatedEntries;
   cloneWithEffect?: TransformNode;
-  effect?: string;
+  effect?: EffectsEnum;
 }
 
 // Textures waiting for the object to spawn.
@@ -325,7 +327,7 @@ export class ObjectHelper {
     });
   }
 
-  static objectEffectChange(objectId: string, effect: string | null) {
+  static objectEffectChange(objectId: string, effect: string) {
     const obj = this.objectsMap.get(objectId);
     if (obj) {
       this.setObjectEffect(objectId, effect);
@@ -334,7 +336,7 @@ export class ObjectHelper {
     }
   }
 
-  static setObjectEffect(objectId: string, effect: string | null) {
+  static setObjectEffect(objectId: string, effect: string) {
     console.log('setObjectEffect', objectId, effect);
     const obj = this.objectsMap.get(objectId);
     if (!obj) {
@@ -342,7 +344,7 @@ export class ObjectHelper {
       return;
     }
 
-    if (effect === null) {
+    if (effect === EffectsEnum.NONE) {
       if (!obj.cloneWithEffect) {
         return;
       }
@@ -357,7 +359,7 @@ export class ObjectHelper {
         element.setEnabled(true);
       });
       console.log('setObjectEffect: original object is visible');
-    } else {
+    } else if (effect === EffectsEnum.TRANSPARENT) {
       if (obj.effect === effect) {
         return;
       }
@@ -396,6 +398,8 @@ export class ObjectHelper {
         element.setEnabled(false);
       });
       console.log('setObjectEffect: original object is hidden');
+    } else {
+      console.log('setObjectEffect: unknown effect:', effect);
     }
   }
 

--- a/packages/core3d/src/core/enums/effects.enum.ts
+++ b/packages/core3d/src/core/enums/effects.enum.ts
@@ -1,0 +1,4 @@
+export enum EffectsEnum {
+  NONE = 'none',
+  TRANSPARENT = 'transparent'
+}

--- a/packages/core3d/src/core/enums/index.ts
+++ b/packages/core3d/src/core/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './effects.enum';

--- a/packages/core3d/src/index.pkg.ts
+++ b/packages/core3d/src/index.pkg.ts
@@ -1,3 +1,4 @@
 export * from './scenes';
 export * from './components';
 export * from './hooks';
+export * from './core/enums';

--- a/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -30,6 +30,7 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
       events.off('AddObject');
       events.off('ObjectTextureChanged');
       events.off('ObjectSoundChanged');
+      events.off('ObjectEffectChanged');
       events.off('ObjectTransform');
       events.off('UserAdded');
       events.off('UserRemoved');
@@ -100,6 +101,10 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
 
       events.on('ObjectSoundChanged', (objectId: string, soundData: ObjectSoundInterface) => {
         ObjectHelper.objectSoundChange(scene, objectId, soundData);
+      });
+
+      events.on('ObjectEffectChanged', (objectId: string, effect: string | null) => {
+        ObjectHelper.objectEffectChange(objectId, effect);
       });
 
       events.on('ObjectTransform', (id, object) => {

--- a/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -103,7 +103,7 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
         ObjectHelper.objectSoundChange(scene, objectId, soundData);
       });
 
-      events.on('ObjectEffectChanged', (objectId: string, effect: string | null) => {
+      events.on('ObjectEffectChanged', (objectId: string, effect: string) => {
         ObjectHelper.objectEffectChange(objectId, effect);
       });
 

--- a/packages/sdk/src/enums/attributeName.enum.ts
+++ b/packages/sdk/src/enums/attributeName.enum.ts
@@ -20,5 +20,6 @@ export enum AttributeNameEnum {
   TIMELINE_LAST_SEEN = 'timeline_last_seen',
   SOUNDTRACK = 'soundtrack',
   SPATIAL_AUDIO = 'spatial_audio',
+  OBJECT_EFFECT = 'object_effect',
   USER_CUSTOMISABLE_DATA = 'user_customisable_data'
 }


### PR DESCRIPTION
A special "transparent" effect can now be applied for Customisable objects that are not yet claimed - it's set after spawning such object and reset if unclaimed (custom content removed).

It's set to "none" when claimed by user - this removes the effect and restores the normal object view.

The "transparent" effect is similar to spawn preview - it's basically cloning the object and sets a special material all its meshes; the original object meshes are disabled. When clearing, it's the opposite - the clone is disposed and the original object is enabled.

The PR also contains the fix for deleting object attribute, which isn't really used here - if deleted, no posbus notification is received - so instead of deleting we're setting the attribute value to "none".

Attribute types from https://github.com/momentum-xyz/ubercontroller/pull/216 are needed here.