### PR TITLE
fix(creator): when claimable object removed, all claimable disappear

### DIFF
--- a/packages/core3d/src/babylon/ObjectHelper.ts
+++ b/packages/core3d/src/babylon/ObjectHelper.ts
@@ -427,6 +427,7 @@ export class ObjectHelper {
   static removeObject(id: string) {
     const objToRemove = this.objectsMap.get(id);
     if (objToRemove) {
+      objToRemove.cloneWithEffect?.dispose();
       objToRemove.objectInstance.dispose();
       objToRemove.container.removeAllFromScene();
       objToRemove.container.dispose();


### PR DESCRIPTION
The cloned object wasn't disposed and it seems it needs to be even before the main object instance