### PR TITLE
fix: duplicated sessions not detected and just keep looping

### DIFF
--- a/packages/app/src/core/types/posBusEvent.type.ts
+++ b/packages/app/src/core/types/posBusEvent.type.ts
@@ -13,6 +13,7 @@ import {
 export type PosBusEventType = {
   'posbus-connected': () => void;
   'posbus-disconnected': () => void;
+  'posbus-duplicated-sessions': () => void;
   notification: (type: PosBusMessageStatusEnum, message: string) => void;
   // collaboration: (type: PosBusCollaborationEnum, channel: string, receiverId: string) => void;
   // broadcast: (broadcast: any) => void;

--- a/packages/app/src/scenes/AppAuth.tsx
+++ b/packages/app/src/scenes/AppAuth.tsx
@@ -3,7 +3,7 @@ import {observer} from 'mobx-react-lite';
 import {useNavigate} from 'react-router-dom';
 import {PositionEnum} from '@momentum-xyz/ui-kit';
 
-import {useStore} from 'shared/hooks';
+import {usePosBusEvent, useStore} from 'shared/hooks';
 import {PosBusService, storage} from 'shared/services';
 import {ROUTES} from 'core/constants';
 import {StorageKeyEnum, WidgetEnum} from 'core/enums';
@@ -42,6 +42,12 @@ const AppAuth: FC<{children: ReactNode}> = ({children}) => {
       PosBusService.init(sessionStore.token, sessionStore.user.id); //, universeStore.worldId || null);
     }
   }, [sessionStore.token, sessionStore.user?.id]); //, universeStore.worldId]);
+
+  usePosBusEvent('posbus-duplicated-sessions', () => {
+    console.log('POSBUS-DUPLICATED-SESSIONS - leave world!');
+    // PosBusService.leaveWorld(); - it's done in PosBusService - doesn't work here
+    navigate({pathname: ROUTES.system.disconnected});
+  });
 
   useEffect(() => {
     if (sessionStore.user && !sessionStore.user.isGuest) {

--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -109,6 +109,10 @@ class PosBusService {
           PosBusEventEmitter.emit('posbus-connected');
         } else if (value === 8) {
           PosBusEventEmitter.emit('posbus-disconnected');
+        } else if (value === 1) {
+          PosBusEventEmitter.emit('posbus-duplicated-sessions');
+          console.log('PosBus duplicated sessions. Leave world!');
+          PosBusService.leaveWorld();
         }
         break;
       }


### PR DESCRIPTION
We now handle posbus signal 1 and leave world and go to disconnected page. There might be a better strategy for handling it as currently both tabs are disconnected.