### PR TITLE
Blockchain: fix loading rewards info

### DIFF
--- a/packages/app/src/scenes/widgets/pages/StakingViewWidget/components/MyWallet/MyWallet.tsx
+++ b/packages/app/src/scenes/widgets/pages/StakingViewWidget/components/MyWallet/MyWallet.tsx
@@ -92,8 +92,11 @@ const MyWallet: FC<PropsInterface> = ({
   const handleClaimRewards = async () => {
     try {
       await claimRewards();
-
       console.log('Claim rewards success');
+
+      setTimeout(() => {
+        handleLoadRewards(selectedWallet?.wallet_id || '');
+      }, 1000);
     } catch (err) {
       console.log('Error claiming rewards:', err);
     }

--- a/packages/app/src/scenes/widgets/pages/StakingViewWidget/components/MyWallet/MyWallet.tsx
+++ b/packages/app/src/scenes/widgets/pages/StakingViewWidget/components/MyWallet/MyWallet.tsx
@@ -65,7 +65,7 @@ const MyWallet: FC<PropsInterface> = ({
   );
 
   useEffect(() => {
-    if (selectedWallet?.wallet_id) {
+    if (selectedWallet?.wallet_id && isBlockchainReady) {
       handleLoadRewards(selectedWallet.wallet_id);
     }
   }, [handleLoadRewards, selectedWallet, isBlockchainReady]);

--- a/packages/app/src/shared/hooks/useBlockchain.tsx
+++ b/packages/app/src/shared/hooks/useBlockchain.tsx
@@ -194,8 +194,11 @@ export const useBlockchain = ({requiredAccountAddress}: UseBlockchainPropsInterf
   const canRequestAirdrop = account ? checkIfCanRequestAirdrop(account) : null;
   const dateOfNextAllowedAirdrop = account ? getDateOfNextAllowedAirdrop(account) : null;
 
+  const contractsCreated = !!stakingContract && !!momContract && !!dadContract && !!faucetContract;
+
   return {
-    isBlockchainReady: isWalletActive && isCorrectAccount && !isWrongNetwork,
+    isBlockchainReady:
+      !!library && contractsCreated && isWalletActive && isCorrectAccount && !isWrongNetwork,
     account,
     walletSelectContent,
     canRequestAirdrop,


### PR DESCRIPTION
It seems in some cases we're calling get_rewards before the contracts are created. This PR should prevent it.