### PR TITLE
feat(creator): assert lock-object-response lock owner

### DIFF
--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -347,9 +347,9 @@ class PosBusService {
           id: objectId
         }
       ]);
-      const onResp = (id: string, result: boolean) => {
+      const onResp = (id: string, result: boolean, lockOwner: string) => {
         if (id === objectId) {
-          if (result) {
+          if (result && lockOwner === this.userId) {
             resolve();
           } else {
             reject(new Error('Object is locked'));


### PR DESCRIPTION
Due to limitations of the protocol we cannot rely on 'result' field only for lock-object operation response - we need to make sure it's not someone else who locked it.