### PR TITLE
Feat/creator/locking additional check

### DIFF
--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -349,7 +349,11 @@ class PosBusService {
       ]);
       const onResp = (id: string, result: boolean, lockOwner: string) => {
         if (id === objectId) {
-          if (result && lockOwner === this.userId) {
+          if (
+            // temp ignore result to make up for the case of object locked by us and us not knowing
+            //result &&
+            lockOwner === this.userId
+          ) {
             resolve();
           } else {
             reject(new Error('Object is locked'));

--- a/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
+++ b/packages/core3d/src/scenes/BabylonScene/BabylonScene.tsx
@@ -123,7 +123,6 @@ const BabylonScene: FC<Odyssey3dPropsInterface> = ({events, renderURL, ...callba
 
       events.on('ObjectTransform', (id, object) => {
         WorldCreatorHelper.setObjectTransform(id, object);
-        console.log('TODO handle ObjectTransform', id, object);
       });
 
       events.on('UserAdded', async (user) => {


### PR DESCRIPTION
Ignore the 'result' to make up for the case object is locked by us but we don't know. Check only if we're lock_owner in the lock-object response.

