### PR TITLE
fix(creator): lock object after spawning

### DIFF
--- a/packages/app/src/shared/services/posBus/PosBusService.tsx
+++ b/packages/app/src/shared/services/posBus/PosBusService.tsx
@@ -219,6 +219,11 @@ class PosBusService {
             },
             PosBusService.attachNextReceivedObjectToCamera
           );
+          if (PosBusService.attachNextReceivedObjectToCamera) {
+            PosBusService.requestObjectLock(object.id).catch((err) => {
+              console.log('Cannot lock object after spawning?!?!', err);
+            });
+          }
 
           PosBusService.attachNextReceivedObjectToCamera = false;
         }

--- a/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
+++ b/packages/app/src/stores/UniverseStore/models/World3dStore/World3dStore.ts
@@ -127,6 +127,7 @@ const World3dStore = types
 
       if (!objectId && self.attachedToCameraObjectId) {
         Event3dEmitter.emit('DetachObjectFromCamera', self.attachedToCameraObjectId);
+        PosBusService.requestObjectUnlock(self.attachedToCameraObjectId);
         const isDuplicatedObject = creatorStore.isDuplicatedObject(self.attachedToCameraObjectId);
         if (isDuplicatedObject) {
           creatorStore.updateDuplicatedObject();


### PR DESCRIPTION
Otherwise the object gets attached to camera and we move it around but the Controller ignores the updates and the position remains the one after the spawn.