### PR TITLE
fix(creator): spawned object rotation is ignored

### DIFF
--- a/packages/core3d/src/babylon/WorldCreatorHelper.ts
+++ b/packages/core3d/src/babylon/WorldCreatorHelper.ts
@@ -286,7 +286,7 @@ export class WorldCreatorHelper {
 
       if (spawn) {
         posToSend = node.absolutePosition;
-        rotToSend = new Vector3(0, 0, 0);
+        rotToSend = node.absoluteRotationQuaternion.toEulerAngles();
         scaleToSend = new Vector3(1, 1, 1);
       } else {
         posToSend = node.position;


### PR DESCRIPTION
This way after we spawn an object and fly around emplacing it - only the position was taken into account, the rotation was always 0/0/0.