### PR TITLE
Show loader in Timeline and Staking while in progress

### DIFF
--- a/packages/app/src/scenes/widgets/pages/StakingWidget/StakingWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/StakingWidget/StakingWidget.tsx
@@ -3,7 +3,7 @@ import {observer} from 'mobx-react-lite';
 import {toast} from 'react-toastify';
 import BN from 'bn.js';
 import {useI18n} from '@momentum-xyz/core';
-import {Frame, Panel, StepInterface, Steps} from '@momentum-xyz/ui-kit';
+import {Frame, Loader, Panel, StepInterface, Steps} from '@momentum-xyz/ui-kit';
 
 import {WidgetEnum} from 'core/enums';
 import {PosBusService} from 'shared/services';
@@ -33,6 +33,7 @@ const StakingWidget: FC<WidgetInfoModelInterface> = ({data}) => {
   const {isBlockchainReady, walletSelectContent, account, stake} = useBlockchain({
     requiredAccountAddress: selectedWalletId
   });
+  const [inProgress, setInProgress] = useState(false);
 
   const worldId = data?.id?.toString() || universeStore.worldId;
   const worldName = world2dStore?.worldDetails?.world?.name || '';
@@ -60,6 +61,7 @@ const StakingWidget: FC<WidgetInfoModelInterface> = ({data}) => {
         worldId,
         amountAtoms
       );
+      setInProgress(true);
       const result = await stake(worldId, amountAtoms, nftStore.currentToken);
       console.log('stake success');
 
@@ -90,6 +92,7 @@ const StakingWidget: FC<WidgetInfoModelInterface> = ({data}) => {
         />
       );
     } finally {
+      setInProgress(false);
       handleOnClose();
     }
   };
@@ -112,6 +115,7 @@ const StakingWidget: FC<WidgetInfoModelInterface> = ({data}) => {
         title={t('staking.label')}
         onClose={handleOnClose}
       >
+        {inProgress && <Loader fill />}
         <styled.Wrapper>
           <styled.Steps>
             <Steps stepList={stepList} />

--- a/packages/app/src/scenes/widgets/pages/TimelineWidget/TimelineWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/TimelineWidget/TimelineWidget.tsx
@@ -10,7 +10,8 @@ import {
   ImageSizeEnum,
   PostImageForm,
   PostVideoForm,
-  PostFormInterface
+  PostFormInterface,
+  Loader
 } from '@momentum-xyz/ui-kit';
 
 import {useStore} from 'shared/hooks';
@@ -130,6 +131,7 @@ const TimelineWidget: FC = () => {
         onClose={() => widgetManagerStore.close(WidgetEnum.TIMELINE)}
       >
         <styled.Wrapper>
+          {isPending && <Loader fill />}
           <AutoSizer>
             {({height, width}: Size) => {
               return (

--- a/packages/app/src/scenes/widgets/pages/TimelineWidget/TimelineWidget.tsx
+++ b/packages/app/src/scenes/widgets/pages/TimelineWidget/TimelineWidget.tsx
@@ -27,6 +27,10 @@ const TimelineWidget: FC = () => {
   const {timelineStore} = widgetStore;
   const {user} = sessionStore;
 
+  // it's important to extract it here,
+  // using isPending={timelineStore.isPending} below in the components doesn't lead to re-render
+  const {isPending} = timelineStore;
+
   const infiniteRef = useRef(null);
   const scrollListRef = useRef<VariableSizeList | null>();
   const entityHeightsRef = useRef({});
@@ -182,7 +186,7 @@ const TimelineWidget: FC = () => {
                           avatarSrc: user.avatarSrc || null,
                           isItMe: true
                         }}
-                        isPending={timelineStore.isPending}
+                        isPending={isPending}
                         screenshot={world3dStore?.screenshotOrVideo?.file}
                         onMakeScreenshot={handleMakeScreenshot}
                         onCreateOrUpdate={(form) => handleCreatePost(form, postTypeIntent)}
@@ -205,7 +209,7 @@ const TimelineWidget: FC = () => {
                           avatarSrc: user.avatarSrc || null,
                           isItMe: true
                         }}
-                        isPending={timelineStore.isPending}
+                        isPending={isPending}
                         video={world3dStore?.screenshotOrVideo?.file}
                         isScreenRecording={universeStore.isScreenRecording}
                         onStartRecording={handleStartRecording}
@@ -239,7 +243,7 @@ const TimelineWidget: FC = () => {
                           created: selectedPost.created_at,
                           hashSrc: getImageAbsoluteUrl(selectedPost.data.hash, ImageSizeEnum.S5)
                         }}
-                        isPending={timelineStore.isPending}
+                        isPending={isPending}
                         screenshot={world3dStore?.screenshotOrVideo?.file}
                         onMakeScreenshot={handleMakeScreenshot}
                         onCreateOrUpdate={(form) => handleUpdatePost(form, selectedPost)}
@@ -272,7 +276,7 @@ const TimelineWidget: FC = () => {
                           created: selectedPost.created_at,
                           hashSrc: getVideoAbsoluteUrl(selectedPost.data.hash)
                         }}
-                        isPending={timelineStore.isPending}
+                        isPending={isPending}
                         video={world3dStore?.screenshotOrVideo?.file}
                         isScreenRecording={universeStore.isScreenRecording}
                         onStartRecording={handleStartRecording}

--- a/packages/ui-kit/src/atoms/Loader/Loader.stories.tsx
+++ b/packages/ui-kit/src/atoms/Loader/Loader.stories.tsx
@@ -1,15 +1,18 @@
 import {Meta, Story} from '@storybook/react';
 
-import {PropsWithThemeInterface} from '../../interfaces';
-
-import Loader from './Loader';
+import Loader, {LoaderPropsInterface} from './Loader';
 
 export default {
   title: 'Atoms/Loader',
   component: Loader
 } as Meta;
 
-const Template: Story<PropsWithThemeInterface> = (args) => <Loader {...args} />;
+const Template: Story<LoaderPropsInterface> = (args) => <Loader {...args} />;
 
 export const General = Template.bind({});
 General.args = {};
+
+export const Fill = Template.bind({});
+Fill.args = {
+  fill: true
+};

--- a/packages/ui-kit/src/atoms/Loader/Loader.styled.ts
+++ b/packages/ui-kit/src/atoms/Loader/Loader.styled.ts
@@ -1,11 +1,22 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.div<{fill?: boolean}>`
   display: flex;
   width: 100%;
   height: 100%;
   justify-content: center;
   align-items: center;
+
+  ${(props) =>
+    props.fill &&
+    `
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
+    border-radius: inherit;
+    background-color: rgba(0, 0, 0, 0.5);
+  `}
 
   @keyframes blink {
     0% {

--- a/packages/ui-kit/src/atoms/Loader/Loader.tsx
+++ b/packages/ui-kit/src/atoms/Loader/Loader.tsx
@@ -1,12 +1,14 @@
 import {FC} from 'react';
 
-import {PropsWithThemeInterface} from '../../interfaces';
-
 import * as styled from './Loader.styled';
 
-const Loader: FC<PropsWithThemeInterface> = () => {
+export interface LoaderPropsInterface {
+  fill?: boolean;
+}
+
+const Loader: FC<LoaderPropsInterface> = ({fill}) => {
   return (
-    <styled.Container data-testid="Loader-test">
+    <styled.Container data-testid="Loader-test" fill={fill}>
       <styled.Item />
       <styled.Item />
       <styled.Item />


### PR DESCRIPTION
The Loader can now be filling up the whole space and blocking clicks as well - so just putting it while in progress.

There was a very weird issue with MST observer not catching the update in the way we're using it.