### PR TITLE
refactor(wallets): rely on wallet internal activation, add callback for the result

### DIFF
--- a/packages/app/src/ui-kit/molecules/WalletSelectHelper/WalletSelectHelper.tsx
+++ b/packages/app/src/ui-kit/molecules/WalletSelectHelper/WalletSelectHelper.tsx
@@ -25,7 +25,7 @@ const WalletSelectHelper: FC<WalletSelectHelperPropsInterface> = ({
   onNetworkStatusChanged
 }) => {
   const {useWallet} = walletConf;
-  const walletProps = {appVariables: appVariables as any};
+  const walletProps = {appVariables: appVariables as any, onActivationDone};
 
   const {t} = useI18n();
   const {web3Library, chainId, account, activate, isActive} = useWallet(walletProps);
@@ -50,15 +50,6 @@ const WalletSelectHelper: FC<WalletSelectHelperPropsInterface> = ({
       onLibraryLoaded(web3Library);
     }
   }, [web3Library, onLibraryLoaded]);
-
-  useEffect(() => {
-    activate()
-      .catch((err) => {
-        console.log('WalletSelectHelper activate err', err);
-        onActivationDone(false);
-      })
-      .finally(() => onActivationDone(true));
-  }, [activate, onActivationDone]);
 
   const isWrongNetwork = !!chainId && chainId !== +appVariables.BLOCKCHAIN_ID;
 

--- a/packages/app/src/ui-kit/organisms/WalletLogin/WalletLogin.tsx
+++ b/packages/app/src/ui-kit/organisms/WalletLogin/WalletLogin.tsx
@@ -28,7 +28,10 @@ const WalletLogin: FC<PropsInterface> = ({
   const {t} = useI18n();
 
   const {signChallenge, content, account, isInstalled, accountHex} = useWallet({
-    appVariables: appVariables as any
+    appVariables: appVariables as any,
+    onActivationDone: (success) => {
+      console.log('WalletLogin onActivationDone, success:', success);
+    }
   });
   console.log('WalletLogin', {name, signChallenge, content, account, accountHex});
 

--- a/packages/app/src/wallets/coinbaseWallet/useWallet.tsx
+++ b/packages/app/src/wallets/coinbaseWallet/useWallet.tsx
@@ -1,17 +1,20 @@
 import {useEffect, useCallback} from 'react';
 import {useWeb3React} from '@web3-react/core';
 import {WalletLinkConnector} from '@web3-react/walletlink-connector';
+import {useMutableCallback} from '@momentum-xyz/ui-kit';
 
 import {UseWalletType} from 'wallets';
 import {SUPPORTED_CHAIN_IDS} from 'wallets/supportedChainIds';
 
-export const useWallet: UseWalletType = ({appVariables}) => {
+export const useWallet: UseWalletType = ({appVariables, onActivationDone}) => {
   const {library, chainId, account, activate, deactivate, active} = useWeb3React();
   console.log('CoinbaseWallet useWallet', {library, account, activate, active});
 
   const {ethereum} = window as any;
   const isInstalled =
     ethereum?.isCoinbaseWallet || !!ethereum?.providers?.some((p: any) => p.isCoinbaseWallet);
+
+  const onActivationDoneCallback = useMutableCallback(onActivationDone);
 
   const activateWallet = useCallback(async () => {
     console.log('CoinbaseWallet useWallet activate', appVariables.WEB3_PUBLIC_RPC_URL_MAINNET);
@@ -26,11 +29,13 @@ export const useWallet: UseWalletType = ({appVariables}) => {
     return activate(connector)
       .then((res) => {
         console.log('CoinbaseWallet useWallet activated res', res);
+        onActivationDoneCallback(true);
       })
       .catch((err) => {
         console.log('CoinbaseWallet useWallet activate err', err);
+        onActivationDoneCallback(false);
       });
-  }, [activate, appVariables]);
+  }, [activate, appVariables, onActivationDoneCallback]);
 
   const signChallenge = useCallback(
     async (challenge: string) => {

--- a/packages/app/src/wallets/metamask/useWallet.tsx
+++ b/packages/app/src/wallets/metamask/useWallet.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useCallback} from 'react';
 import {useWeb3React} from '@web3-react/core';
 import {InjectedConnector} from '@web3-react/injected-connector';
+import {useMutableCallback} from '@momentum-xyz/ui-kit';
 
 import {UseWalletType} from 'wallets';
 import {SUPPORTED_CHAIN_IDS} from 'wallets/supportedChainIds';
@@ -9,7 +10,7 @@ const connector = new InjectedConnector({
   supportedChainIds: SUPPORTED_CHAIN_IDS
 });
 
-export const useWallet: UseWalletType = () => {
+export const useWallet: UseWalletType = ({onActivationDone}) => {
   const {library, chainId, account, activate, deactivate, active} = useWeb3React();
   console.log('MetaMask useWallet', {library, account, activate, active});
 
@@ -27,6 +28,8 @@ export const useWallet: UseWalletType = () => {
     },
     [account, library]
   );
+
+  const onActivationDoneCallback = useMutableCallback(onActivationDone);
 
   const activateWallet = useCallback(async () => {
     console.log('MetaMask useWallet activate');
@@ -49,15 +52,17 @@ export const useWallet: UseWalletType = () => {
         activate(connector)
           .then((res) => {
             console.log('MetaMask useWallet activated res', res);
+            onActivationDoneCallback(true);
             resolve();
           })
           .catch((err) => {
             console.log('MetaMask useWallet activate err', err);
+            onActivationDoneCallback(false);
             reject(err);
           });
       }, 500);
     });
-  }, [activate, ethereum, metamaskProvider]);
+  }, [activate, ethereum, metamaskProvider, onActivationDoneCallback]);
 
   useEffect(() => {
     if (!isInstalled) {

--- a/packages/app/src/wallets/talisman/useWallet.tsx
+++ b/packages/app/src/wallets/talisman/useWallet.tsx
@@ -10,6 +10,7 @@ import {
 // import {hexlify} from '@ethersproject/bytes';
 // import {toUtf8Bytes} from '@ethersproject/strings';
 import {useWeb3React} from '@web3-react/core';
+import {useMutableCallback} from '@momentum-xyz/ui-kit';
 
 import {UseWalletType} from 'wallets';
 import {SUPPORTED_CHAIN_IDS} from 'wallets/supportedChainIds';
@@ -32,7 +33,7 @@ const talismanConnector = new TalismanConnector({
 //   }
 // };
 
-export const useWallet: UseWalletType = ({appVariables}) => {
+export const useWallet: UseWalletType = ({appVariables, onActivationDone}) => {
   const {library, chainId, account, activate, deactivate, active} = useWeb3React();
   console.log('Talisman useWallet', {library, account, activate, active});
 
@@ -43,6 +44,8 @@ export const useWallet: UseWalletType = ({appVariables}) => {
 
   const talismanEth = (window as any)?.talismanEth;
   const isInstalled = !!talismanEth;
+
+  const onActivationDoneCallback = useMutableCallback(onActivationDone);
 
   const activateWallet = useCallback(async () => {
     // const enable = async () => {
@@ -65,6 +68,7 @@ export const useWallet: UseWalletType = ({appVariables}) => {
         activate(talismanConnector)
           .then((res) => {
             console.log('Talisman useWallet activated res', res);
+            onActivationDoneCallback(true);
             resolve();
             // talismanEth
             //   .request({method: 'eth_requestAccounts'})
@@ -77,11 +81,12 @@ export const useWallet: UseWalletType = ({appVariables}) => {
           })
           .catch((err) => {
             console.log('Talisman useWallet activate err', err);
+            onActivationDoneCallback(false);
             reject(err);
           });
       }, 500);
     });
-  }, [activate]);
+  }, [activate, onActivationDoneCallback]);
 
   useEffect(() => {
     if (!isInstalled) {

--- a/packages/app/src/wallets/wallets.types.ts
+++ b/packages/app/src/wallets/wallets.types.ts
@@ -14,6 +14,7 @@ export interface UseWalletHookReturnInterface {
 }
 export interface UseWalletPropsInterface {
   appVariables: {[key: string]: string};
+  onActivationDone: (success: boolean) => void;
 }
 
 export type UseWalletType = (props: UseWalletPropsInterface) => UseWalletHookReturnInterface;


### PR DESCRIPTION
We had double activation - in WalletSelectHelper and wallets themselves. It might be causing problems with Talisman wallet activation in prod.

Refactored to use the activation inside useWallet of selected wallet, adding callback reporting success/fail of this operation.

Alternative could be calling activate from WalletLogin, same as in WalletSelectHelper. The problem with it is that some wallets have specifics - like waiting 0.5 seconds before calling activate, perhaps something else. But we could have this 0.5 sec timeout for all of them or implement it inside activate callback function, so it's a valid alternative.