### PR TITLE
Refactor babylon: wrap object stuff into class

### DIFF
--- a/packages/core3d/src/babylon/ObjectInstance.ts
+++ b/packages/core3d/src/babylon/ObjectInstance.ts
@@ -1,0 +1,151 @@
+import {
+  Scene,
+  SceneLoader,
+  AssetContainer,
+  PBRMaterial,
+  InstantiatedEntries,
+  TransformNode,
+  Color3
+} from '@babylonjs/core';
+import {Object3dInterface, ObjectTransformInterface} from '@momentum-xyz/core';
+
+import {EffectsEnum} from '../index.pkg';
+
+import {getAssetFileName} from './UtilityHelper';
+import {ObjectHelper} from './ObjectHelper';
+import {posToVec3} from './TransformHelper';
+
+export class ObjectInstance {
+  scene: Scene;
+
+  protected container?: AssetContainer;
+  objectDefinition: Object3dInterface;
+  protected objectInstance?: InstantiatedEntries;
+  protected cloneWithEffect?: TransformNode;
+  protected effect?: EffectsEnum;
+
+  constructor(scene: Scene, objectDefinition: Object3dInterface) {
+    this.scene = scene;
+    this.objectDefinition = objectDefinition;
+  }
+
+  async load(): Promise<void> {
+    const assetUrl = getAssetFileName(this.objectDefinition.asset_3d_id);
+    const object = this.objectDefinition;
+
+    this.container = await SceneLoader.LoadAssetContainerAsync(
+      ObjectHelper.assetRootUrl,
+      assetUrl,
+      this.scene,
+      (event) => {
+        // On progress callback
+        //console.log(`Loading progress ${event.loaded}/${event.total}`);
+      },
+      '.glb'
+    );
+    // this.instantiateObject(container, object, attachToCam);
+
+    const instance = this.container.instantiateModelsToScene();
+    const node = instance.rootNodes[0];
+    if (!(node instanceof TransformNode)) {
+      console.log(
+        'instance.rootNodes.length === 0. Something went wrong with loading ' + object.asset_3d_id
+      );
+      throw new Error('Unable to load the object');
+    }
+
+    node.name = object.name;
+
+    node.position = posToVec3(object.transform.position);
+    node.rotation = posToVec3(object.transform.rotation);
+    node.scaling = posToVec3(object.transform.scale);
+    node.metadata = object.id;
+
+    // Play animations
+    for (const group of instance.animationGroups) {
+      group.play(true);
+    }
+  }
+
+  dispose(): void {
+    this.objectInstance?.dispose();
+    this.container?.removeFromScene();
+    this.container?.dispose();
+    this.cloneWithEffect?.dispose();
+  }
+
+  getNode(): TransformNode {
+    return this.cloneWithEffect || (this.objectInstance?.rootNodes[0] as TransformNode);
+  }
+
+  setTransform(transform: ObjectTransformInterface): void {
+    const node = this.getNode();
+    node.position = posToVec3(transform.position);
+    node.rotation = posToVec3(transform.rotation);
+    node.scaling = posToVec3(transform.scale);
+  }
+
+  setEffect(effect: EffectsEnum, force = false): void {
+    if (!this.objectInstance) {
+      throw new Error('ObjectInstance not loaded');
+    }
+
+    if (effect === EffectsEnum.NONE) {
+      if (!this.cloneWithEffect) {
+        return;
+      }
+      console.log('setObjectEffect: removing effect');
+      this.cloneWithEffect.dispose();
+      this.cloneWithEffect = undefined;
+      this.effect = undefined;
+
+      // make sure the object is visible
+      const childMeshes = this.objectInstance.rootNodes[0].getChildMeshes();
+      childMeshes.forEach((element) => {
+        element.setEnabled(true);
+      });
+      console.log('setObjectEffect: original object is visible');
+    } else if (effect === EffectsEnum.TRANSPARENT) {
+      if (this.effect === effect && !force) {
+        return;
+      }
+      if (this.cloneWithEffect) {
+        this.cloneWithEffect.dispose();
+      }
+
+      const node = this.objectInstance.rootNodes[0];
+      const clone = node.clone('clone', node.parent);
+      if (!(clone instanceof TransformNode)) {
+        console.log('setObjectEffect: clone is not a TransformNode');
+        return;
+      }
+      // const effectMat = new StandardMaterial('effect', this.scene);
+      const effectMat = new PBRMaterial('effect', this.scene);
+      effectMat.albedoColor = Color3.Teal();
+      effectMat.emissiveColor = Color3.White();
+      effectMat.reflectivityColor = Color3.Green();
+      effectMat.alpha = 0.7;
+
+      const cloneChildren = clone.getChildMeshes();
+      cloneChildren.forEach((element) => {
+        element.material = effectMat;
+        // console.log('setObjectEffect:', objectId, 'element', element, element.material);
+        // if (element.material) {
+        //   element.material.alpha = 0.4;
+        // }
+      });
+      console.log('setObjectEffect: effect added');
+
+      this.cloneWithEffect = clone;
+      this.effect = effect;
+
+      const childMeshes = node.getChildMeshes();
+      childMeshes.forEach((element) => {
+        element.setEnabled(false);
+      });
+      console.log('setObjectEffect: original object is hidden');
+    } else {
+      console.log('setObjectEffect: unknown effect:', effect);
+    }
+  }
+}

--- a/packages/core3d/src/babylon/UtilityHelper.ts
+++ b/packages/core3d/src/babylon/UtilityHelper.ts
@@ -8,7 +8,7 @@ export function getAssetFileName(id: string): string {
 
 export function getNodeFromId(id: string): TransformNode | undefined {
   const obj = ObjectHelper.objectsMap.get(id);
-  const myNode = obj?.cloneWithEffect || obj?.objectInstance.rootNodes[0];
+  const myNode = obj?.getNode();
   if (myNode instanceof TransformNode) {
     return myNode;
   } else {

--- a/packages/core3d/src/babylon/UtilityHelper.ts
+++ b/packages/core3d/src/babylon/UtilityHelper.ts
@@ -1,19 +1,7 @@
 import {TransformNode, Vector3} from '@babylonjs/core';
 
-import {ObjectHelper} from './ObjectHelper';
-
 export function getAssetFileName(id: string): string {
   return id.replace(/-/g, '');
-}
-
-export function getNodeFromId(id: string): TransformNode | undefined {
-  const obj = ObjectHelper.objectsMap.get(id);
-  const myNode = obj?.getNode();
-  if (myNode instanceof TransformNode) {
-    return myNode;
-  } else {
-    return undefined;
-  }
 }
 
 export function getBoundingInfo(node: TransformNode): {

--- a/packages/core3d/src/babylon/WorldCreatorHelper.ts
+++ b/packages/core3d/src/babylon/WorldCreatorHelper.ts
@@ -25,7 +25,6 @@ import yScale_red from '../static/Gizmo/scale_red.glb';
 import zScale_green from '../static/Gizmo/scale_green.glb';
 import scale_uniform from '../static/Gizmo/scale_origin.glb';
 
-import {getNodeFromId} from './UtilityHelper';
 import {vec3ToPos} from './TransformHelper';
 import {ObjectHelper} from './ObjectHelper';
 
@@ -335,8 +334,7 @@ export class WorldCreatorHelper {
       this.setGizmoType(GizmoTypesEnum.Rotation);
       this.setGizmoType(GizmoTypesEnum.Scale);
 
-      // TODO remove this helper?
-      const node = getNodeFromId(objectId);
+      const node = ObjectHelper.objectsMap.get(objectId)?.getNode();
 
       if (node) {
         this.gizmoManager.attachToNode(node);
@@ -357,8 +355,7 @@ export class WorldCreatorHelper {
     const id = on ? objectId : this.selectedObjectId;
     this.selectedObjectId = id;
 
-    // TODO remove this helper?
-    const node = getNodeFromId(id);
+    const node = ObjectHelper.objectsMap.get(id)?.getNode();
     console.log('toggleHightlightObject', {objectId, on, node});
 
     const meshes = node?.getChildMeshes();

--- a/packages/core3d/src/babylon/WorldCreatorHelper.ts
+++ b/packages/core3d/src/babylon/WorldCreatorHelper.ts
@@ -26,7 +26,7 @@ import zScale_green from '../static/Gizmo/scale_green.glb';
 import scale_uniform from '../static/Gizmo/scale_origin.glb';
 
 import {getNodeFromId} from './UtilityHelper';
-import {vec3ToPos, posToVec3} from './TransformHelper';
+import {vec3ToPos} from './TransformHelper';
 import {ObjectHelper} from './ObjectHelper';
 
 export enum GizmoTypesEnum {
@@ -315,12 +315,7 @@ export class WorldCreatorHelper {
       return;
     }
 
-    const transformNode = ObjectHelper.objectsMap.get(id)?.objectInstance.rootNodes[0];
-    if (transformNode instanceof TransformNode) {
-      transformNode.position = posToVec3(transform.position);
-      transformNode.rotation = posToVec3(transform.rotation);
-      transformNode.scaling = posToVec3(transform.scale);
-    }
+    ObjectHelper.objectsMap.get(id)?.setTransform(transform);
   }
 
   static toggleCreatorMode() {
@@ -340,6 +335,7 @@ export class WorldCreatorHelper {
       this.setGizmoType(GizmoTypesEnum.Rotation);
       this.setGizmoType(GizmoTypesEnum.Scale);
 
+      // TODO remove this helper?
       const node = getNodeFromId(objectId);
 
       if (node) {
@@ -361,6 +357,7 @@ export class WorldCreatorHelper {
     const id = on ? objectId : this.selectedObjectId;
     this.selectedObjectId = id;
 
+    // TODO remove this helper?
     const node = getNodeFromId(id);
     console.log('toggleHightlightObject', {objectId, on, node});
 

--- a/packages/core3d/src/core/enums/effects.enum.ts
+++ b/packages/core3d/src/core/enums/effects.enum.ts
@@ -1,4 +1,5 @@
 export enum EffectsEnum {
   NONE = 'none',
-  TRANSPARENT = 'transparent'
+  TRANSPARENT = 'transparent',
+  SPAWN_PREVIEW = 'spawn-preview'
 }


### PR DESCRIPTION
It allows hiding some implementation details for effects and instantiating in it without taking it into consideration on many places across this module.

Should also fix issues with transform and setting color on claimable objects