### PR TITLE
fix: fly to infinite sized object

### DIFF
--- a/packages/core3d/src/babylon/PlayerHelper.ts
+++ b/packages/core3d/src/babylon/PlayerHelper.ts
@@ -328,7 +328,7 @@ export class PlayerHelper {
     // Calculate a comfortable distance from the object from certain direction
     const direction = new Vector3(0, 0, -1); // Example direction
     direction.normalize();
-    direction.scaleInPlace(size + 2);
+    direction.scaleInPlace(Math.max(size, 4200) + 2);
     console.log('PlayerHelper flyToObject', {size, direction});
 
     this.camera.lockedTarget = targetNode.position;


### PR DESCRIPTION
Limit the maximum distance of flyTo_object.

Certain 'broken' glb cause their size to be infinite (or very large), so limit this to some (arbitrary) size.

4200, because at around 5000 skybox starts clipping