### PR TITLE
Creator: Inspector - change object name

### DIFF
--- a/packages/app/src/scenes/widgets/pages/CreatorWidget/pages/ObjectInspector/ObjectInspector.styled.ts
+++ b/packages/app/src/scenes/widgets/pages/CreatorWidget/pages/ObjectInspector/ObjectInspector.styled.ts
@@ -41,3 +41,10 @@ export const Separator = styled.div`
   background: ${(props) => props.theme.accentText && rgba(props.theme.accentText, 0.4)};
   margin: 20px 0;
 `;
+
+export const Form = styled.div`
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 10px;
+  align-items: center;
+`;

--- a/packages/app/src/scenes/widgets/pages/CreatorWidget/pages/ObjectInspector/ObjectInspector.tsx
+++ b/packages/app/src/scenes/widgets/pages/CreatorWidget/pages/ObjectInspector/ObjectInspector.tsx
@@ -2,7 +2,7 @@ import {FC} from 'react';
 import {observer} from 'mobx-react-lite';
 import {Model3dPreview} from '@momentum-xyz/core3d';
 import {useI18n} from '@momentum-xyz/core';
-import {Frame} from '@momentum-xyz/ui-kit';
+import {Frame, Input, useDebouncedCallback} from '@momentum-xyz/ui-kit';
 
 import {Asset3d} from 'core/models';
 import {useStore} from 'shared/hooks';
@@ -15,8 +15,10 @@ import {TransformInterface} from './components/ObjectTransformForm/ObjectTransfo
 const ObjectInspector: FC = () => {
   const {widgetStore} = useStore();
   const {creatorStore} = widgetStore;
-  const {objectName, objectInfo, spawnAssetStore, selectedObjectId} = creatorStore;
+  const {objectName, objectInfo, spawnAssetStore, selectedObjectId, saveObjectName} = creatorStore;
   const {assets3dBasic, assets3dCustom} = spawnAssetStore;
+
+  const debounceSaveObjectName = useDebouncedCallback(saveObjectName, 500);
 
   const {t} = useI18n();
 
@@ -73,7 +75,11 @@ const ObjectInspector: FC = () => {
     <styled.Container data-testid="ObjectInspector-test">
       <styled.Section>
         <Frame>
-          <styled.Title>{objectName}</styled.Title>
+          <styled.Form>
+            <div>Name</div>
+            <Input value={objectName} onChange={debounceSaveObjectName} wide />
+          </styled.Form>
+
           <styled.ObjectPreviewModelContainer>
             {actualObjectAsset && (
               <Model3dPreview

--- a/packages/app/src/scenes/widgets/stores/CreatorStore/CreatorStore.ts
+++ b/packages/app/src/scenes/widgets/stores/CreatorStore/CreatorStore.ts
@@ -40,6 +40,7 @@ const CreatorStore = types
       getObjectNameRequest: types.optional(RequestModel, {}),
 
       duplicateObjectRequest: types.optional(RequestModel, {}),
+      saveObjectNameRequest: types.optional(RequestModel, {}),
       removeObjectDialog: types.optional(Dialog, {}),
       removeObjectRequest: types.optional(RequestModel, {})
     })
@@ -115,6 +116,23 @@ const CreatorStore = types
       }
 
       return clonedObjectId;
+    }),
+    saveObjectName: flow(function* (name: string) {
+      if (!self.selectedObjectId) {
+        return;
+      }
+
+      yield self.saveObjectNameRequest.send(api.spaceAttributeRepository.setSpaceAttributeItem, {
+        spaceId: self.selectedObjectId,
+        plugin_id: PluginIdEnum.CORE,
+        attribute_name: AttributeNameEnum.NAME,
+        sub_attribute_key: AttributeNameEnum.NAME,
+        value: name
+      });
+
+      if (!self.saveObjectNameRequest.isError) {
+        self.objectName = name;
+      }
     })
   }));
 


### PR DESCRIPTION
The object name in the Inspector is saved on server on change with 500msec debounce.

It could be implemented with appearing Save/Discard buttons for Name field only but would be nice to have this behaviour for the whole Inspector which isn't the case right now. Needs to be checked additionally with UX team.

Another unpleasant effect of our ui-kit Input is that it doesn't trigger `onChange` in case of Undo (Cmd+Z/Ctrl+Z) - it's done visually though. If someone changes the name, then undoes it - it will not update the server!